### PR TITLE
[WIP] Dynamically generate revision number.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,38 @@ ENDIF()
 
 add_subdirectory("avs_core")
 add_subdirectory("plugins")
+
+# Dynamically generate the version info so that the sequential revision in Version() doesn't literally say 'rXXX'
+# Based on an example given on the CMake mailing list: http://www.cmake.org/pipermail/cmake/2010-July/038015.html
+
+FIND_PACKAGE(Git)
+
+# Protect against the (somewhat typical) case of git being installed to Program Files
+set(GIT "${GIT_EXECUTABLE}")
+
+FILE(WRITE ${CMAKE_BINARY_DIR}/main.c
+    "\#include \"avs_core/core/version.h\"\nint main(void){return 0;}\n"
+)
+
+FILE(WRITE ${CMAKE_BINARY_DIR}/version.h.in
+    "\#define AVS_SEQREV \"@AVS_SEQREV@\"\n"
+)
+
+FILE(WRITE ${CMAKE_BINARY_DIR}/version.cmake
+    "EXECUTE_PROCESS(
+         COMMAND \"@GIT@\" rev-list --count HEAD
+         OUTPUT_VARIABLE AVS_SEQREV
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+     )
+     CONFIGURE_FILE(\${SRC} \${DST} @ONLY)
+")
+
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
+ADD_EXECUTABLE(main main.c)
+ADD_CUSTOM_TARGET(
+    version
+    ${CMAKE_COMMAND} -D SRC=${CMAKE_BINARY_DIR}/version.h.in
+                     -D DST=${CMAKE_BINARY_DIR}/avs_core/core/version.h
+                     -P ${CMAKE_BINARY_DIR}/version.cmake
+)
+ADD_DEPENDENCIES(main version)

--- a/avs_core/core/internal.h
+++ b/avs_core/core/internal.h
@@ -37,6 +37,7 @@
 #define __Internal_H__
 
 #include <avs/config.h>
+#include "version.h"
 
 #ifdef X86_32
 #define AVS_ARCHSTR "x86"
@@ -45,7 +46,7 @@
 #endif
 
 #define AVS_VERSION 2.60  // Note: Used by VersionNumber() script function
-#define AVS_VERSTR "AviSynth+ 0.1 (rXXX, " AVS_ARCHSTR ")"
+#define AVS_VERSTR "AviSynth+ 0.1 (r" AVS_SEQREV ", " AVS_ARCHSTR ")"
 #define AVS_COPYRIGHT "\n\xA9 2000-2013 Ben Rudiak-Gould, et al.\nhttp://avisynth.nl\n\xA9 2013 AviSynth+ Project\nhttp://avs-plus.net"
 
 extern const char _AVS_VERSTR[], _AVS_COPYRIGHT[];


### PR DESCRIPTION
With the recent versioning change, I wanted to look at the output of Version() from the official build.  However, I couldn't check the official build because it silently fails for me.  So I built my own with VS2010 - that build works fine.

The issue was that my VS2010 build showed the literal 'rXXX' placeholder that was inserted into internal.h.  I'm not sure if the officially released build actually showed r1555 or if it doing so was the result of manually editing it; as I mentioned before, it just silently fails (my guess is that the build is tuned explicitly for SSE2, analogous to GCC's -march/-mtune flags; I know there's an option in Visual Studio to control this, but I can't remember what it's called).

Anyway, this patch abstracts this so that the revision number is automatically generated.  It uses cmake itself to call git and write the output to version.h, which internal.h then calls in.

This is very much a work-in-progress.  A couple points that I'm unsure about:
A) The description in the mailing list was focused on the issue of not having to regenerate version.h when some files get changed, or avoiding having to re-run the cmake step to get it regenerated, or something like that.  Whether or not this behavior is desired here (or if it would be noticed at all) is an open question, I guess.

B) What to point rev-list at: the patch points it at HEAD because if a user checks out a previous revision, it will report the revision number of that checked out commit.
