### PR TITLE
Faster horizontal resizer

### DIFF
--- a/avs_core/filters/resample.cpp
+++ b/avs_core/filters/resample.cpp
@@ -403,7 +403,7 @@ __forceinline static void resize_v_create_pitch_table(int* table, int pitch, int
  ********* Horizontal Resizer** ********
  ***************************************/
 
-void resize_h_prepare_coeff_8(ResamplingProgram* p) {
+static void resize_h_prepare_coeff_8(ResamplingProgram* p) {
   int filter_size = AlignNumber(p->filter_size, 8);
   short* new_coeff = (short*) _aligned_malloc(sizeof(short) * p->target_size * filter_size, 64);
   memset(new_coeff, 0, sizeof(short) * p->target_size * filter_size);
@@ -423,7 +423,7 @@ void resize_h_prepare_coeff_8(ResamplingProgram* p) {
   p->pixel_coefficient = new_coeff;
 }
 
-void resize_h_c_planar(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height) {
+static void resize_h_c_planar(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height) {
   int filter_size = program->filter_size;
   short* current = program->pixel_coefficient;
 
@@ -442,8 +442,8 @@ void resize_h_c_planar(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch,
   }
 }
 
-void resizer_h_ssse3_generic(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height) {
   int filter_size = AlignNumber(program->filter_size, 8) / 8;
+static void resizer_h_ssse3_generic(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height) {
 
   __m128i zero = _mm_setzero_si128();
 
@@ -521,7 +521,7 @@ void resizer_h_ssse3_generic(BYTE* dst, const BYTE* src, int dst_pitch, int src_
   }
 }
 
-void resizer_h_ssse3_8(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height) {
+static void resizer_h_ssse3_8(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height) {
   int filter_size = AlignNumber(program->filter_size, 8) / 8;
 
   __m128i zero = _mm_setzero_si128();

--- a/avs_core/filters/resample.cpp
+++ b/avs_core/filters/resample.cpp
@@ -442,9 +442,8 @@ static void resize_h_c_planar(BYTE* dst, const BYTE* src, int dst_pitch, int src
   }
 }
 
-  int filter_size = AlignNumber(program->filter_size, 8) / 8;
 static void resizer_h_ssse3_generic(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height) {
-
+  int filter_size = AlignNumber(program->filter_size, 8) / 8;
   __m128i zero = _mm_setzero_si128();
 
   for (int y = 0; y < height; y++) {

--- a/avs_core/filters/resample.cpp
+++ b/avs_core/filters/resample.cpp
@@ -673,6 +673,7 @@ FilteredResizeH::FilteredResizeH( PClip _child, double subrange_left, double sub
     const int shift_h = vi.GetPlaneHeightSubsampling(PLANAR_U);
     const int div   = 1 << shift;
 
+
     resampling_program_chroma = func->GetResamplingProgram(
       vi.width       >> shift,
       subrange_left   / div,
@@ -691,7 +692,7 @@ FilteredResizeH::FilteredResizeH( PClip _child, double subrange_left, double sub
     }
   }
 
-  if (resampling_program_luma->filter_size == 1) {
+  if (resampling_program_luma->filter_size == 1 && vi.IsPlanar()) {
     fast_resize = true;
     resampler_h_luma = resize_h_pointresize;
     resampler_h_chroma = resize_h_pointresize;

--- a/avs_core/filters/resample.h
+++ b/avs_core/filters/resample.h
@@ -40,6 +40,7 @@
 
 // Resizer function pointer
 typedef void (*ResamplerV)(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int target_height, const int* pitch_table, const void* storage);
+typedef void (*ResamplerH)(BYTE* dst, const BYTE* src, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int target_height);
 
 // Turn function pointer -- copied from turn.h
 typedef void (*TurnFuncPtr) (const BYTE *srcp, BYTE *dstp, int width, int height, int src_pitch, int dst_pitch);
@@ -55,6 +56,9 @@ public:
                    ResamplingFunction* func, IScriptEnvironment* env );
   virtual ~FilteredResizeH(void);
   PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment* env);
+
+  static ResamplerH GetResampler(int CPU, bool aligned, ResamplingProgram* program);
+
 private:
   // Resampling
   ResamplingProgram *resampling_program_luma;
@@ -71,6 +75,9 @@ private:
   int   temp_1_pitch, temp_2_pitch;
 
   int src_width, src_height, dst_width,  dst_height;
+
+  ResamplerH resampler_h_luma;
+  ResamplerH resampler_h_chroma;
 
   ResamplerV resampler_luma;
   ResamplerV resampler_chroma;
@@ -90,7 +97,7 @@ public:
   virtual ~FilteredResizeV(void);
   PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment* env);
 
-  static ResamplerV FilteredResizeV::GetResampler(int CPU, bool aligned, void*& storage, ResamplingProgram* program);
+  static ResamplerV GetResampler(int CPU, bool aligned, void*& storage, ResamplingProgram* program);
 
 private:
   ResamplingProgram *resampling_program_luma;

--- a/avs_core/filters/resample.h
+++ b/avs_core/filters/resample.h
@@ -78,6 +78,7 @@ private:
 
   ResamplerH resampler_h_luma;
   ResamplerH resampler_h_chroma;
+  bool fast_resize;
 
   ResamplerV resampler_luma;
   ResamplerV resampler_chroma;


### PR DESCRIPTION
According to test on Sandy Bridge, Ivy Bridge and Nehalem, this actually beats or as fast as 2.6a5 resizers now.

Improvements:
- Faster horizontal scaling on most resizers on CPU with SSSE3 support and mod4-clip (both luma and chroma) on planar colorspace.
- Much faster horizontal point scaling
