### PR TITLE
Fixes for avisynth_c.h library header usage

### DIFF
--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -40,9 +40,9 @@ Please NOTE! This version of avisynth.h DOES NOT have any special exemption!
 #ifndef __AVISYNTH_6_H__
 #define __AVISYNTH_6_H__
 
-#include <avs/config.h>
-#include <avs/capi.h>
-#include <avs/types.h>
+#include "avs/config.h"
+#include "avs/capi.h"
+#include "avs/types.h"
 
 
 enum { AVISYNTH_INTERFACE_VERSION = 6 };
@@ -857,7 +857,7 @@ public:
 
 
 
-#include <avs/cpuid.h>
+#include "avs/cpuid.h"
 
 
 
@@ -1048,7 +1048,7 @@ IScriptEnvironment* __stdcall CreateScriptEnvironment(int version = AVISYNTH_INT
 
 
 // C exports
-#include <avs/capi.h>
+#include "avs/capi.h"
 AVSC_API(IScriptEnvironment2*, CreateScriptEnvironment2)(int version = AVISYNTH_INTERFACE_VERSION);
 
 

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -201,16 +201,17 @@ enum {
     AVS_CACHE_ACCESS_SEQ1=263, // Filter needs sequential access (high cost)
   };
 
-typedef struct AVS_Clip AVS_Clip;
-
 #ifdef BUILDING_AVSCORE
-typedef struct AVS_ScriptEnvironment {
+struct AVS_ScriptEnvironment {
 	IScriptEnvironment * env;
 	const char * error;
 	AVS_ScriptEnvironment(IScriptEnvironment * e = 0)
 		: env(e), error(0) {}
-} AVS_ScriptEnvironment;
+};
 #endif
+
+typedef struct AVS_Clip AVS_Clip;
+typedef struct AVS_ScriptEnvironment AVS_ScriptEnvironment;
 
 /////////////////////////////////////////////////////////////////////
 //

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -297,7 +297,7 @@ AVSC_API(int, avs_bits_per_pixel)(const AVS_VideoInfo * p);
 
 AVSC_API(int, avs_bytes_from_pixels)(const AVS_VideoInfo * p, int pixels);
 
-AVSC_API(int, avs_row_size)(const AVS_VideoInfo * p, int plane=0);
+AVSC_API(int, avs_row_size)(const AVS_VideoInfo * p, int plane);
 
 AVSC_API(int, avs_bmp_size)(const AVS_VideoInfo * vi);
 

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -38,9 +38,9 @@
 #ifndef __AVISYNTH_C__
 #define __AVISYNTH_C__
 
-#include <avs/config.h>
-#include <avs/capi.h>
-#include <avs/types.h>
+#include "avs/config.h"
+#include "avs/capi.h"
+#include "avs/types.h"
 
 
 /////////////////////////////////////////////////////////////////////

--- a/avs_core/include/avs/config.h
+++ b/avs_core/include/avs/config.h
@@ -44,12 +44,12 @@
 // builds possible.
 #define FRAME_ALIGN 32
 
-#ifdef _M_AMD64
-  #define X86_64
-#elif  _M_IX86
-  #define X86_32
+#if   defined(_M_AMD64) || defined(__x86_64)
+#   define X86_64
+#elif defined(_M_IX86) || defined(__i386__)
+#   define X86_32
 #else
-  #error Unsupported CPU architecture.
+#   error Unsupported CPU architecture.
 #endif
 
 #endif //AVS_CONFIG_H


### PR DESCRIPTION
Particularly relevant for Libav.  This fixes some compilation errors when trying to build the libavformat AviSynth demuxer against the newer RC1-updated C header.  There's also a fix that has to be added on the Libav side, but these are the ones that Avs+ needs.

The issues were a bit scattered:
- AVS_ScriptEnvironment does need to be defined in some basic state for the demuxer to compile.
- The GCC i386/amd64 detection needed to be added from the Linux branch.  Otherwise, the --enable-avisynth ./configure check would fail.
- When using the GNUmakefile, the headers are installed to the avisynth/ subdirectory in includedir, which due to the absolute references to avs/ in avisynth.h and avisynth_c.h, ends up requiring the user to specifically add the {includedir}/avisynth directory to their CFLAGS instead of it just working.  This is more a simple adjustment for convenience, since it can be done with --extra-cflags (more that the user shouldn't have to remember that caveat).  I also adjusted it in avisynth.h so plugins could take advantage of system-installed headers.