### PR TITLE
Integrate changes from 2.6 RC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,38 @@ Visit our [homepage](http://avs-plus.net) for more information and binaries, or 
 [forum thread](http://forum.doom9.org/showthread.php?t=168856) for compilation instructions and support.
 
 
+Building the documentation:
+---------------------------
+
+AviSynth+'s documentation can be generated into HTML by using Sphinx.
+
+### Set-up:
+
+Make sure that Sphinx is installed. This requires that Python is already
+installed and the pip tool is available.  Sphinx 1.3 is the recommended
+version.
+
+>pip install sphinx
+
+For various Linux distributions, a Sphinx package should be available
+in the distro's repositories.  Often under the name 'python-sphinx'
+(as it is in Ubuntu's repositories).
+
+There is currently a fallback so that distros that only provide
+Sphinx 1.2 can still build the documentation.  It will look
+different than when built with Sphinx 1.3, because the theme
+used with Sphinx 1.3 (bizstyle) had not yet been added to the main
+Sphinx package.
+
+### Building the documentation
+
+Once Sphinx is installed, we can build the documentation.
+
+>cd distrib/docs/english
+
+>make html
+
+
 Libav users:
 ------------
 

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ provided specifically for this purpose.
 
 #### To uninstall:
 
->make uninstall
+>make uninstall PREFIX=/path/to/location

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -18,21 +18,22 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA, or visit
 // http://www.gnu.org/copyleft/gpl.html .
 //
-// Linking Avisynth statically or dynamically with other modules is making a
-// combined work based on Avisynth.  Thus, the terms and conditions of the GNU
-// General Public License cover the whole combination.
-
-
-/*
-Please NOTE! This version of avisynth.h DOES NOT have any special exemption!
-
-         While this version is under development you are fully
-       constrained by the terms of the GNU General Public License.
-
- Any derivative software you may publish MUST include the full source code.
-
-    Normal licence conditions will be reapplied in a future version.
-*/
+// Linking Avisynth statically or dynamically with other modules is making
+// a combined work based on Avisynth.  Thus, the terms and conditions of
+// the GNU General Public License cover the whole combination.
+//
+// As a special exception, the copyright holders of Avisynth give you
+// permission to link Avisynth with independent modules that communicate
+// with Avisynth solely through the interfaces defined in avisynth.h,
+// regardless of the license terms of these independent modules, and to
+// copy and distribute the resulting combined work under terms of your
+// choice, provided that every copy of the combined work is accompanied
+// by a complete copy of the source code of Avisynth (the version of
+// Avisynth used to produce the combined work), being distributed under
+// the terms of the GNU General Public License plus this exception.  An
+// independent module is a module which is not derived from or based on
+// Avisynth, such as 3rd-party filters, import and export plugins, or
+// graphical user interfaces.
 
 
 

--- a/distrib/ColorPresets/colors_rgb.avsi
+++ b/distrib/ColorPresets/colors_rgb.avsi
@@ -108,7 +108,6 @@ global color_orange                 = $FFA500
 global color_orangered              = $FF4500
 global color_orchid                 = $DA70D6
 global color_palegoldenrod          = $EEE8AA
-global color_palegoldenrod          = $EEE8AA
 global color_palegreen              = $98FB98
 global color_paleturquoise          = $AFEEEE
 global color_palevioletred          = $DB7093

--- a/distrib/FilterSDK/FilterSDK.htm
+++ b/distrib/FilterSDK/FilterSDK.htm
@@ -215,7 +215,7 @@ in AviSynth.
 </p>
 <p>...</p>
 <h2><a class="mozTocH2" name="mozTocId450057"></a><span class="editsection"></span><span class="mw-headline" id="What.27s_new_in_the_2.6_api">What's
-new in the 2.6 api </span></h2>
+new in the 2.6 api</span></h2>
 <ul>
 <li>
 C++ API (AVISYNTH_INTERFACE_VERSION = 6):
@@ -270,13 +270,16 @@ C++ API (AVISYNTH_INTERFACE_VERSION = 6):
   <li>
   Some new cache and cpu constants for GetCPUFlags (the v5/v6 ones).
   </li>
+  <li>
+  SetCacheHints changed from void to int.
+  </li>
   </ul>
 </li>
 </ul>
 
 <ul>
 <li>
-C API (AVISYNTH_INTERFACE_VERSION = 5):
+C API (AVISYNTH_INTERFACE_VERSION = 6):
   <ul>
   <li>
   The following functions are added to the interface: avs_is_yv24, avs_is_yv16,
@@ -320,7 +323,7 @@ terms </span></h2>
 <p>Note: Avisynth Filter SDK parts are under specific <a href="SDKLicense.htm" title="Filter SDK/SDK license">SDK
 license terms</a>.
 </p>
-<p><kbd>$Date: 2015/01/13 00:24:50 $<br />
+<p><kbd>$Date: 2015/01/27 19:37:22 $<br />
 Latest online mediaWiki version is at <a href="http://avisynth.nl/Filter_SDK">http://avisynth.nl/Filter_SDK</a>
 </kbd></p>
 </body></html>

--- a/distrib/FilterSDK/GettingStartedWithAudio.htm
+++ b/distrib/FilterSDK/GettingStartedWithAudio.htm
@@ -17,20 +17,48 @@
 
 <p>Basically you override GetAudio(...) instead of GetFrame, and fill the
   buffer with data. A simple filter could look like this:</p>
-<h4>Filter creation - skip if no audio:</h4> 
-<pre>AVSValue __cdecl HalfVolume::Create(AVSValue args, void*, IScriptEnvironment* env) {<br />  if (!args[0].AsClip()-&gt;GetVideoInfo().AudioChannels())<br />    return args[0];<br /><br />  return new HalfVolume(args[0].AsClip());<br />}<br /></pre>
+<h4>Filter creation - skip if no audio:</h4>
+<pre>AVSValue __cdecl HalfVolume::Create(AVSValue args, void*, IScriptEnvironment* env) {
+  if (!args[0].AsClip()-&gt;GetVideoInfo().HasAudio())
+      return args[0];
+
+  // Auto convert audio to a compatible format.
+  AVSValue CA_args[3] = { args[0], SAMPLE_INT16 | SAMPLE_FLOAT, SAMPLE_FLOAT };
+  PClip clip = env-&gt;Invoke("ConvertAudio", AVSValue(CA_args, 3)).AsClip();
+
+  return new HalfVolume(clip);
+}</pre>
+<p>What <code>ConvertAudio()</code> does is, that you tell it that your filter supports
+   SAMPLE_INT16 and SAMPLE_FLOAT, and that it prefers SAMPLE_FLOAT. If the input isn't
+   16 bit or float, it'll be converted to float, otherwise the original PClip is returned.</p>
 <h4>Constructor:</h4>
-<pre>HalfVolume::HalfVolume(PClip _child)<br />    : GenericVideoFilter(ConvertAudio::Create(_child, SAMPLE_INT16 | SAMPLE_FLOAT, SAMPLE_FLOAT)) {   <br />}<br /></pre>
-<p>This is a bit tricky. It'll require you to include
-  <a href="http://avisynth2.cvs.sourceforge.net/avisynth2/avisynth/src/audio/convertaudio.cpp?view=markup"><code>ConvertAudio.cpp</code></a>. 
-  What it does is automatic sample type conversion.  Basically what it does is
-  that you tell that your filter supports SAMPLE_INT16 and SAMPLE_FLOAT, and
-  that it prefers SAMPLE_FLOAT. If the input isn't 16 bit or float, it'll be
-  converted to float.</p>
-<h4>GetAudio override:</h4> 
-<pre>void __stdcall HalfVolume::GetAudio(void* buf, __int64 start, __int64 count, IScriptEnvironment* env) {<br />  child-&gt;GetAudio(buf, start, count, env);<br />  int channels = vi.AudioChannels();<br /><br />  if (vi.SampleType() == SAMPLE_INT16) {<br />    short* samples = (short*)buf;<br />    for (int i=0; i&lt; count; i++) {<br />      for(int j=0;j&lt; channels;j++) {<br />         samples[i*channels+j] /= 2;<br />      }<br />    }<br />  } else if (vi.SampleType() == SAMPLE_FLOAT) {<br />    SFLOAT* samples = (SFLOAT*)buf;<br />    for (int i=0; i&lt; count; i++) {<br />      for(int j=0;j&lt; channels;j++) {<br />         samples[i*channels+j] /= 2.0f;<br />      }<br />    }<br />  }<br />}<br /></pre>
+<pre>HalfVolume::HalfVolume(PClip _child)
+    : GenericVideoFilter(_child) { // Provide null GetFrame, GetParity, etc
+} </pre>
+<h4>GetAudio override:</h4>
+<pre>void __stdcall HalfVolume::GetAudio(void* buf, __int64 start, __int64 count, IScriptEnvironment* env) {
+  child-&gt;GetAudio(buf, start, count, env);
+  int channels = vi.AudioChannels();
+
+  if (vi.SampleType() == SAMPLE_INT16) {
+    short* samples = (short*)buf;
+    for (int i=0; i&lt; count; i++) {
+      for(int j=0;j&lt; channels;j++) {
+         samples[i*channels+j] += 1; // Round
+         samples[i*channels+j] /= 2; // Halve
+      }
+    }
+  } else if (vi.SampleType() == SAMPLE_FLOAT) {
+    SFLOAT* samples = (SFLOAT*)buf;
+    for (int i=0; i&lt; count; i++) {
+      for(int j=0;j&lt; channels;j++) {
+         samples[i*channels+j] /= 2.0f; // Halve, rounding not needed
+      }
+    }
+  }
+}</pre>
 <p>Implementation of a half volume filter. Very explicit, so it isn't going to
-  be the fastest possible, but it should serve the purpose. Furthermore have a look 
+  be the fastest possible, but it should serve the purpose. Furthermore have a look
   <a href="http://forum.doom9.org/showthread.php?s=&amp;threadid=72760&amp;highlight=ConvertAudiohere">discussion here</a>
   and look also at
   <a href="http://avisynth2.cvs.sourceforge.net/avisynth2/avisynth/src/audio/audio.cpp?view=markup"><code>audio.cpp</code></a>
@@ -39,6 +67,8 @@
 
 </p><hr style="width: 100%; height: 2px;" />Back to&nbsp;<a href="FilterSDK.htm">FilterSDK</a>
 </div>
-<p><kbd>$Date: 2014/10/27 22:04:54 $<br /><a href="http://www.avisynth.org/GettingStartedWithAudio"></a>
+<p><kbd>
+    $Date: 2015/03/31 05:00:17 $
+    <a href="http://www.avisynth.org/GettingStartedWithAudio"></a>
   </kbd></p>
 </body></html>

--- a/distrib/FilterSDK/SDKNecessaries.htm
+++ b/distrib/FilterSDK/SDKNecessaries.htm
@@ -79,5 +79,5 @@ There is also <a rel="nofollow" class="external text" href="http://forum.doom9.o
 </p><p>There is also <a rel="nofollow" class="external text" href="http://www.codeplex.com/AvsFilterNet">AvsFilterNet</a> wrapper for Avisynth in .NET (any .NET language) by SAPikachu, see <a rel="nofollow" class="external text" href="http://forum.doom9.org/showthread.php?t=144663">discussion</a>
 </p><hr style="width: 100%; height: 2px;" />Back to <a href="FilterSDK.htm">FilterSDK</a>
 
-<p><kbd>$Date: 2015/01/27 19:37:22 $</kbd></p>
+<p><kbd>$Date: 2015/03/30 06:08:10 $</kbd></p>
 </body></html>

--- a/distrib/FilterSDK/SDKNecessaries.htm
+++ b/distrib/FilterSDK/SDKNecessaries.htm
@@ -49,7 +49,7 @@ AVISYNTH_INTERFACE_VERSION = 3. Plugins compiled with them will work in
 v2.5.6 and up, and v2.5.5 and below if you do not use new interface
 features and do not call env-&gt;CheckVersion function.
 </p><p>Now being developed, AviSynth version 2.6.x will use <a href="http://avisynth.nl/images/Avisynth.h-2.6.0.avs" class="internal" title="Avisynth.h-2.6.0.avs">new header avisynth.h</a>,
- currently with AVISYNTH_INTERFACE_VERSION = 5. Plugins compiled with
+ currently with AVISYNTH_INTERFACE_VERSION = 6. Plugins compiled with
 AviSynth v2.5.x header will work in AviSynth 2.6.x too, but plugins
 compiled with new AviSynth v2.6.x header will probably not work in
 AviSynth v2.5.x.
@@ -57,7 +57,7 @@ AviSynth v2.5.x.
 as a draft for improving or own development. Attention: there are many
 old plugins source code packages with older avisynth.h included. Simply replace it by new one.
 </p>
-<h2><span class="editsection"></span><span class="mw-headline" id="Compiling_options">&nbsp;Compiling options </span></h2>
+<h2><span class="editsection"></span><span class="mw-headline" id="Compiling_options">&nbsp;Compiling options</span></h2>
 <p>Plugin CPP source code must be compiled as Win32 DLL (multi-threaded or multi-threaded DLL) without MFC.
 </p><p>Notes. If you use Visual C++ Toolkit 2003 itself (without VC++
 7), you can not build plugin as multi-treaded DLL: the toolkit missed
@@ -79,5 +79,5 @@ There is also <a rel="nofollow" class="external text" href="http://forum.doom9.o
 </p><p>There is also <a rel="nofollow" class="external text" href="http://www.codeplex.com/AvsFilterNet">AvsFilterNet</a> wrapper for Avisynth in .NET (any .NET language) by SAPikachu, see <a rel="nofollow" class="external text" href="http://forum.doom9.org/showthread.php?t=144663">discussion</a>
 </p><hr style="width: 100%; height: 2px;" />Back to <a href="FilterSDK.htm">FilterSDK</a>
 
-<p><kbd>$Date: 2014/10/27 22:04:54 $</kbd></p>
+<p><kbd>$Date: 2015/01/27 19:37:22 $</kbd></p>
 </body></html>

--- a/distrib/docs/english/source/avisynthdoc/FilterSDK/FilterSDK.rst
+++ b/distrib/docs/english/source/avisynthdoc/FilterSDK/FilterSDK.rst
@@ -184,8 +184,9 @@ What's new in the 2.6 api
       constants, GetPlaneHeightSubsampling,
       GetPlaneWidthSubsampling).
     - Some new cache and cpu constants for GetCPUFlags (the v5/v6 ones).
+    - SetCacheHints changed from void to int.
 
-- C API (AVISYNTH_INTERFACE_VERSION = 5):
+- C API (AVISYNTH_INTERFACE_VERSION = 6):
     - The following functions are added to the interface:
       avs_is_yv24, avs_is_yv16, avs_is_yv12, avs_is_yv411,
       avs_is_y8, avs_is_color_space,
@@ -223,7 +224,7 @@ License terms
 
 Note: Avisynth Filter SDK parts are under specific :doc:`SDK license <SDKLicense>` terms.
 
-$Date: 2015/01/13 00:24:50 $
+$Date: 2015/01/27 19:37:22 $
 
 Latest online mediaWiki version is at http://avisynth.nl/Filter_SDK
 

--- a/distrib/docs/english/source/avisynthdoc/FilterSDK/SDKNecessaries.rst
+++ b/distrib/docs/english/source/avisynthdoc/FilterSDK/SDKNecessaries.rst
@@ -72,8 +72,8 @@ Header file avisynth.h from v2.5.6 to v2.5.8 are almost identical and have
 v2.5.6 and up, and v2.5.5 and below if you do not use new
 interface features and do not call ``env->CheckVersion`` function.
 
-New being developed, AviSynth version 2.6.x will use new header avisynth.h,
-currently with ``AVISYNTH_INTERFACE_VERSION = 5.`` Plugins compiled with
+Now being developed, AviSynth version 2.6.x will use new header avisynth.h,
+currently with ``AVISYNTH_INTERFACE_VERSION = 6.`` Plugins compiled with
 AviSynth v2.5.x header will work in AviSynth 2.6.x too, but plugins compiled
 with new AviSynth v2.6.x header will probably not work in AviSynth v2.5.x.
 
@@ -123,7 +123,7 @@ language) by SAPikachu, see `discussion`_
 
 Back to :doc:`FilterSDK <FilterSDK>`
 
-$Date: 2014/10/27 22:04:54 $
+$Date: 2015/03/30 06:08:10 $
 
 .. _[1]: 
    http://www.google.nl/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&ved=0CCoQFjAA&url=http://go.microsoft.com/?linkid=7729279&ei=HfWhUuTjL8Og0wW7wYDwBw&usg=AFQjCNEulTGchEeozkLGRH8LZELiTKlC5A&sig2=Mi7Rwn_jNL5Qffi7LiGS3w&bvm=bv.57752919,d.d2k

--- a/plugins/DirectShowSource/directshow_source.cpp
+++ b/plugins/DirectShowSource/directshow_source.cpp
@@ -2597,8 +2597,8 @@ AVSValue __cdecl Create_DirectShowSource(AVSValue args, void*, IScriptEnvironmen
     else if (!lstrcmpi(pixel_type, "FULL"))  { _media = GetSample::mediaFULL; }
     else {
       env->ThrowError("DirectShowSource: pixel_type must be \"RGB24\", \"RGB32\", \"ARGB\", "
-                      "\"YUY2\", \"YV12\", \"YV16\", \"YV24\", \"AYUV\", \"Y41P\", \"Y411\", "
-                      "\"NV12\", \"RGB\", \"YUV\" , \"YUVex\", \"AUTO\"  or \"FULL\"");
+                      "\"YUY2\", \"YV12\", \"I420\", \"YV16\", \"YV24\", \"AYUV\", \"Y41P\", "
+                      "\"Y411\", \"NV12\", \"RGB\", \"YUV\" , \"YUVex\", \"AUTO\"  or \"FULL\"");
     }
     if (mediaPad) _media |= GetSample::mediaPAD;
   }


### PR DESCRIPTION
I noticed earlier this morning that RC2 had been released a few days ago, so I did the same thing I did for RC1 and looked at what needed to be merged.  The answer is a very underwhelming 'almost nothing', because most of the 14 commits that make up RC2 touch parts that have been removed from AviSynth+ entirely.

```
HTML		0001-corrections.patch
HTML		0003-Fix-No-newline-at-end-of-file.patch
HTML		0013-Use-env-Invoke-ConvertAudio-.-in-example.patch

applies-1	0002-one-instance-of-color_palegoldenrod-removed.patch
applies-2	0006-Add-I420-to-message.patch

rejected-1	0007-Remove-AlignPlanar.patch
rejected-2	0008-Release-candicate-2.patch
rejected-3	0009-Support-2.6-colour-spaces.-Wilbert.patch
rejected-4	0010-Remove-AlignPlanar.patch
rejected-5	0011-Change-default-install-dir-to-PROGRAMFILES-AviSynth-.patch
rejected-6	0014-Change-www.avisynth.org-to-www.avisynth.nl.patch
rejected-7	0004-Release-candicate-2.patch
rejected-8	0005-Bump-version-for-extended-cache-requests.patch
rejected-9	0012-Release-candicate-2.patch

HTML		Changes to the HTML documentation; irrelevant in normal form since avsplus uses
		reStructuredText+Sphinx, but the content can be migrated.  The one about newlines
		at end of files is irrelevant unless some other change is in there too.

		Since all three of these commits go into the FilterSDK and there's still an HTML
		copy of the FilterSDK in the avsplus source, these get applied twice: once as HTML,
		and then the content is migrated over to RST. No real need to have three discrete
		commits for the RST version, so they're all going in in one commit.

rejected-1-4	avsplus doesn't have TCPDeliver in its source tree, it uses the DLL from classic's distro

rejected-5	NSI script is irrelevant to avsplus, and avsplus uses a different directory name anyway

rejected-6	Already changed in avsplus during the version refactoring.

rejected-7	All changes to either TCPDeliver (doesn't exist in avsplus source tree) or to .rc files
		making it register with a bumped '2,6,0,x' version, which avsplus no longer identifies as

rejected-8	avsplus cache refactoring made this irrelevant

rejected-9	It looks like it's just a straight copy of the new avisynth.h into DSS' plugin sources,
		replacing the old one.  avsplus made this irrelevant, probably long long ago, by making
		DSS refer to the avisynth.h in include/, not one in its own sources.

applies-1	Applies cleanly, but needs the path changed from distrib/color_presets to distrib/ColorPresets

applies-2	Applies cleanly, but needs the path to be changed from src/plugins/DirectShowSource to plugins/DirectShowSource
```

What made this more fun is that jeeb hasn't mirrored these commits yet (so the modifications to the RC2 commits and cherry-picking *can't* currently be forced over the old *theirs* history).  With this in mind, #22 and this quirk could be solved by having a classic_avisynth branch where we can pull in CVS changes ourselves if we have to.  I have such a branch pushed onto my repo.