### PR TITLE
avisynth_c: Fix 64-bit C plugin loading

### DIFF
--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -773,9 +773,15 @@ bool PluginManager::TryAsAvs25(PluginFile &plugin, AVSValue *result)
 
 bool PluginManager::TryAsAvsC(PluginFile &plugin, AVSValue *result)
 {
+#ifdef _WIN64
+  AvisynthCPluginInitFunc AvisynthCPluginInit = (AvisynthCPluginInitFunc)GetProcAddress(plugin.Library, "avisynth_c_plugin_init");
+  if (!AvisynthCPluginInit)
+    AvisynthCPluginInit = (AvisynthCPluginInitFunc)GetProcAddress(plugin.Library, "_avisynth_c_plugin_init@4");
+#else // _WIN32
   AvisynthCPluginInitFunc AvisynthCPluginInit = (AvisynthCPluginInitFunc)GetProcAddress(plugin.Library, "_avisynth_c_plugin_init@4");
   if (!AvisynthCPluginInit)
     AvisynthCPluginInit = (AvisynthCPluginInitFunc)GetProcAddress(plugin.Library, "avisynth_c_plugin_init@4");
+#endif
 
   if (AvisynthCPluginInit == NULL)
     return false;


### PR DESCRIPTION
Otherwise 64-bit C plugins are rejected as invalid.

(I'd initially tried to use a cleaner approach with *#define*s at the top of PluginManager.cpp, but that didn't pan out, so I resorted to this instead.)