### PR TITLE
VSprintf, parser: force decimal separator "." for float formatting (+ PixelType)

### DIFF
--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -54,6 +54,7 @@
 #include <cassert>
 #include "MTGuard.h"
 #include "cache.h"
+#include <clocale>
 
 #ifdef _MSC_VER
   #define strnicmp(a,b,c) _strnicmp(a,b,c)
@@ -2270,7 +2271,9 @@ char* ScriptEnvironment::VSprintf(const char* fmt, void* val) {
     size += 4096;
     buf = new(std::nothrow) char[size];
     if (!buf) return NULL;
-    count = _vsnprintf(buf, size, fmt, (va_list)val);
+    _locale_t locale = _create_locale(LC_NUMERIC, "C"); // decimal point: dot
+    count = _vsnprintf_l(buf, size, fmt, locale, (va_list)val);
+    _free_locale(locale);
   }
   return string_dump.SaveString(buf, count); // SaveString will add the NULL in len mode.
 }

--- a/avs_core/core/parser/script.cpp
+++ b/avs_core/core/parser/script.cpp
@@ -43,6 +43,7 @@
 #include <avs/win.h>
 #include <avs/minmax.h>
 #include <new>
+#include <clocale>
 #include "../internal.h"
 #include "../Prefetcher.h"
 
@@ -889,7 +890,9 @@ AVSValue String(AVSValue args, void*, IScriptEnvironment* env)
 	  }
 	  if (args[0].IsFloat()) {
 		char s[30];
-		sprintf(s,"%lf",args[0].AsFloat());
+    _locale_t locale = _create_locale(LC_NUMERIC, "C"); // decimal point: dot
+    _sprintf_l(s,"%lf", locale, args[0].AsFloat());
+    _free_locale(locale);
 		return env->SaveString(s);
 	  }
   }

--- a/avs_core/core/parser/script.cpp
+++ b/avs_core/core/parser/script.cpp
@@ -827,7 +827,23 @@ AVSValue PixelType (AVSValue args, void*, IScriptEnvironment* env) {
 	  return "YV411";
     case VideoInfo::CS_Y8    :
 	  return "Y8";
-	default:
+    case VideoInfo::CS_YUV420P16 :
+    return "YUV420P16";
+    case VideoInfo::CS_YUV422P16 :
+    return "YUV422P16";
+    case VideoInfo::CS_YUV444P16 :
+    return "YUV444P16";
+    case VideoInfo::CS_Y16       :
+    return "Y16";
+    case VideoInfo::CS_YUV420PS  :
+    return "YUV420PS";
+    case VideoInfo::CS_YUV422PS  :
+    return "YUV422PS";
+    case VideoInfo::CS_YUV444PS  :
+    return "YUV444PS";
+    case VideoInfo::CS_Y32       :
+    return "Y32";
+    default:
 	  break;
   }
   return "";


### PR DESCRIPTION
For both formats of String() script function: String(float [,formatstring])