### PR TITLE
8/16/32 bit ConvertToYUV420/422/444 like ConvertToYV12/YV16/YV24

### DIFF
--- a/avs_core/convert/convert.cpp
+++ b/avs_core/convert/convert.cpp
@@ -62,6 +62,10 @@ extern const AVSFunction Convert_filters[] = {       // matrix can be "rec601", 
   { "ConvertBackToYUY2", BUILTIN_FUNC_PREFIX, "c[matrix]s", ConvertBackToYUY2::Create },
   { "ConvertHbdFromStacked", BUILTIN_FUNC_PREFIX, "c", ConvertHbdFromStacked::Create },
   { "ConvertHbdToStacked", BUILTIN_FUNC_PREFIX, "c", ConvertHbdToStacked::Create },
+  { "ConvertToY",       BUILTIN_FUNC_PREFIX, "c[matrix]s", ConvertToY8::Create },
+  { "ConvertToYUV420",  BUILTIN_FUNC_PREFIX, "c[interlaced]b[matrix]s[ChromaInPlacement]s[chromaresample]s[ChromaOutPlacement]s", ConvertToPlanarGeneric::CreateYUV420},
+  { "ConvertToYUV422",  BUILTIN_FUNC_PREFIX, "c[interlaced]b[matrix]s[ChromaInPlacement]s[chromaresample]s", ConvertToPlanarGeneric::CreateYUV422},
+  { "ConvertToYUV444",  BUILTIN_FUNC_PREFIX, "c[interlaced]b[matrix]s[ChromaInPlacement]s[chromaresample]s", ConvertToPlanarGeneric::CreateYUV444},
   { 0 }
 };
 

--- a/avs_core/convert/convert_planar.h
+++ b/avs_core/convert/convert_planar.h
@@ -153,8 +153,12 @@ public:
   static AVSValue __cdecl CreateYV16(AVSValue args, void*, IScriptEnvironment* env);   
   static AVSValue __cdecl CreateYV24(AVSValue args, void*, IScriptEnvironment* env);   
   static AVSValue __cdecl CreateYV411(AVSValue args, void*, IScriptEnvironment* env);   
+  static AVSValue __cdecl CreateYUV420(AVSValue args, void*, IScriptEnvironment* env);   
+  static AVSValue __cdecl CreateYUV422(AVSValue args, void*, IScriptEnvironment* env);   
+  static AVSValue __cdecl CreateYUV444(AVSValue args, void*, IScriptEnvironment* env);   
 private:
-  bool Y8input;
+  bool Yinput;
+  int pixelsize;
   PClip Usource;
   PClip Vsource;
 };

--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -775,6 +775,11 @@ void ScriptEnvironment::InitMT()
     this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertToYUY2", MtMode::MT_NICE_FILTER, true);
     this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertBackToYUY2", MtMode::MT_NICE_FILTER, true);
 
+    this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertToY", MtMode::MT_NICE_FILTER, true);
+    this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertToYUV420", MtMode::MT_NICE_FILTER, true);
+    this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertToYUV422", MtMode::MT_NICE_FILTER, true);
+    this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertToYUV444", MtMode::MT_NICE_FILTER, true);
+
     this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertNativeToStacked", MtMode::MT_NICE_FILTER, true);
     this->SetFilterMTMode(BUILTIN_FUNC_PREFIX "_ConvertStackedToNative", MtMode::MT_NICE_FILTER, true);
 


### PR DESCRIPTION
As 8 bit counterparts, conversions within bit depth. ConvertToYV12/16/24 remained for 8 bit (naming)
Also new: ConvertToY. Though ConvertToY8 silently allows higher bitdepths.