### PR TITLE
10-/12-/14-bit stuff (NOT READY YET)

### DIFF
--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -1975,6 +1975,8 @@ PVideoFrame __stdcall ScriptEnvironment::NewVideoFrame(const VideoInfo& vi, int 
     case VideoInfo::CS_YV411:
     case VideoInfo::CS_I420:
     // AVS16 do not reject when a filter requests it
+    case VideoInfo::CS_BGR48:
+    case VideoInfo::CS_BGR64:
     case VideoInfo::CS_YUV420P10:
     case VideoInfo::CS_YUV422P10:
     case VideoInfo::CS_YUV444P10:
@@ -1995,7 +1997,12 @@ PVideoFrame __stdcall ScriptEnvironment::NewVideoFrame(const VideoInfo& vi, int 
     case VideoInfo::CS_YUV422PS:
     case VideoInfo::CS_YUV444PS:
     case VideoInfo::CS_Y32:
-      break;
+    case VideoInfo::CS_GBRP:
+    case VideoInfo::CS_GBRP10:
+    case VideoInfo::CS_GBRP12:
+    case VideoInfo::CS_GBRP14:
+    case VideoInfo::CS_GBRP16:
+          break;
     default:
       ThrowError("Filter Error: Filter attempted to create VideoFrame with invalid pixel_type.");
   }

--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -1975,6 +1975,18 @@ PVideoFrame __stdcall ScriptEnvironment::NewVideoFrame(const VideoInfo& vi, int 
     case VideoInfo::CS_YV411:
     case VideoInfo::CS_I420:
     // AVS16 do not reject when a filter requests it
+    case VideoInfo::CS_YUV420P10:
+    case VideoInfo::CS_YUV422P10:
+    case VideoInfo::CS_YUV444P10:
+    case VideoInfo::CS_Y10:
+    case VideoInfo::CS_YUV420P12:
+    case VideoInfo::CS_YUV422P12:
+    case VideoInfo::CS_YUV444P12:
+    case VideoInfo::CS_Y12:
+    case VideoInfo::CS_YUV420P14:
+    case VideoInfo::CS_YUV422P14:
+    case VideoInfo::CS_YUV444P14:
+    case VideoInfo::CS_Y14:
     case VideoInfo::CS_YUV420P16:
     case VideoInfo::CS_YUV422P16:
     case VideoInfo::CS_YUV444P16:

--- a/avs_core/core/avisynth_c.cpp
+++ b/avs_core/core/avisynth_c.cpp
@@ -63,6 +63,54 @@ int AVSC_CC avs_is_y8(const AVS_VideoInfo * p)
   { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y8    & AVS_CS_PLANAR_FILTER); }
 
 extern "C"
+int AVSC_CC avs_is_yuv444p10(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV444P10 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv422p10(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV422P10 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv420p10(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV420P10 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_y10(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y10   & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv444p12(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV444P12 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv422p12(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV422P12 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv420p12(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV420P12 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_y12(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y12   & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv444p14(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV444P14 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv422p14(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV422P14 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv420p14(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV420P14 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_y14(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y14   & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
 int AVSC_CC avs_is_yuv444p16(const AVS_VideoInfo * p)
   { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV444P16 & AVS_CS_PLANAR_FILTER); }
 

--- a/avs_core/core/avisynth_c.cpp
+++ b/avs_core/core/avisynth_c.cpp
@@ -43,6 +43,14 @@ public:
 //
 
 extern "C"
+int AVSC_CC avs_is_rgb48(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_BGR48) == AVS_CS_BGR48; }
+
+extern "C"
+int AVSC_CC avs_is_rgb64(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_BGR64) == AVS_CS_BGR64; }
+
+extern "C"
 int AVSC_CC avs_is_yv24(const AVS_VideoInfo * p)
   { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YV24  & AVS_CS_PLANAR_FILTER); }
 
@@ -141,6 +149,26 @@ int AVSC_CC avs_is_yuv420ps(const AVS_VideoInfo * p)
 extern "C"
 int AVSC_CC avs_is_y32(const AVS_VideoInfo * p)
   { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y32   & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_gbrp(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_GBRP  & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_gbrp10(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_GBRP10 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_gbrp12(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_GBRP12 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_gbrp14(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_GBRP14 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_gbrp16(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_GBRP16 & AVS_CS_PLANAR_FILTER); }
 
 extern "C"
 int AVSC_CC avs_is_color_space(const AVS_VideoInfo * p, int c_space)

--- a/avs_core/core/interface.cpp
+++ b/avs_core/core/interface.cpp
@@ -215,6 +215,10 @@ int VideoInfo::BitsPerPixel() const {
         return 24;
       case CS_BGR32:
         return 32;
+      case CS_BGR48:
+        return 48;
+      case CS_BGR64:
+        return 64;
       case CS_YUY2:
         return 16;
       case CS_Y8:
@@ -294,6 +298,7 @@ int VideoInfo::NumComponents() const {
   case CS_Y32:
     return 1;
   case CS_BGR32:
+  case CS_BGR64:
     return 4;
   default:
     return 3;
@@ -327,7 +332,11 @@ int VideoInfo::ComponentSize() const {
   case CS_YUV444P16:
   case CS_YUV422P16:
   case CS_YUV420P16:
-    return 2;
+  case CS_GBRP10:
+  case CS_GBRP12:
+  case CS_GBRP14:
+  case CS_GBRP16:
+      return 2;
   default:
     return 1;
   }

--- a/avs_core/core/interface.cpp
+++ b/avs_core/core/interface.cpp
@@ -311,6 +311,18 @@ int VideoInfo::ComponentSize() const {
   case CS_YUV420PS:
   case CS_Y32:
     return 4;
+  case CS_Y10:
+  case CS_YUV444P10:
+  case CS_YUV422P10:
+  case CS_YUV420P10:
+  case CS_Y12:
+  case CS_YUV444P12:
+  case CS_YUV422P12:
+  case CS_YUV420P12:
+  case CS_Y14:
+  case CS_YUV444P14:
+  case CS_YUV422P14:
+  case CS_YUV420P14:
   case CS_Y16:
   case CS_YUV444P16:
   case CS_YUV422P16:

--- a/avs_core/core/parser/script.cpp
+++ b/avs_core/core/parser/script.cpp
@@ -815,7 +815,11 @@ AVSValue PixelType (AVSValue args, void*, IScriptEnvironment* env) {
 	  return "RGB24";
     case VideoInfo::CS_BGR32 :
 	  return "RGB32";
-    case VideoInfo::CS_YUY2  :
+    case VideoInfo::CS_BGR48 :
+	  return "RGB48";
+    case VideoInfo::CS_BGR64 :
+	  return "RGB64";
+	case VideoInfo::CS_YUY2  :
 	  return "YUY2";
     case VideoInfo::CS_YV24  :
 	  return "YV24";
@@ -846,6 +850,16 @@ AVSValue PixelType (AVSValue args, void*, IScriptEnvironment* env) {
     return "YUV444PS";
     case VideoInfo::CS_Y32       :
     return "Y32";
+    case VideoInfo::CS_GBRP      :
+      return "GBRP";
+    case VideoInfo::CS_GBRP10    :
+      return "GBRP10";
+    case VideoInfo::CS_GBRP12    :
+      return "GBRP12";
+    case VideoInfo::CS_GBRP14    :
+      return "GBRP14";
+    case VideoInfo::CS_GBRP16    :
+      return "GBRP16";
     default:
 	  break;
   }

--- a/avs_core/filters/source.cpp
+++ b/avs_core/filters/source.cpp
@@ -229,6 +229,10 @@ static AVSValue __cdecl Create_BlankClip(AVSValue args, void*, IScriptEnvironmen
       vi.pixel_type = VideoInfo::CS_BGR24;
     } else if (!lstrcmpi(pixel_type_string, "RGB32")) {
       vi.pixel_type = VideoInfo::CS_BGR32;
+    } else if (!lstrcmpi(pixel_type_string, "RGB48")) {
+      vi.pixel_type = VideoInfo::CS_BGR48;
+    } else if (!lstrcmpi(pixel_type_string, "RGB64")) {
+      vi.pixel_type = VideoInfo::CS_BGR64;
     } else if (!lstrcmpi(pixel_type_string, "YUV420P16")) {
       vi.pixel_type = VideoInfo::CS_YUV420P16;
     } else if (!lstrcmpi(pixel_type_string, "YUV422P16")) {
@@ -245,8 +249,18 @@ static AVSValue __cdecl Create_BlankClip(AVSValue args, void*, IScriptEnvironmen
       vi.pixel_type = VideoInfo::CS_YUV444PS;
     } else if (!lstrcmpi(pixel_type_string, "Y32")) {
       vi.pixel_type = VideoInfo::CS_Y32;
+    } else if (!lstrcmpi(pixel_type_string, "GBRP")) {
+      vi.pixel_type = VideoInfo::CS_GBRP;
+    } else if (!lstrcmpi(pixel_type_string, "GBRP10")) {
+      vi.pixel_type = VideoInfo::CS_GBRP10;
+    } else if (!lstrcmpi(pixel_type_string, "GBRP12")) {
+      vi.pixel_type = VideoInfo::CS_GBRP12;
+    } else if (!lstrcmpi(pixel_type_string, "GBRP14")) {
+      vi.pixel_type = VideoInfo::CS_GBRP14;
+    } else if (!lstrcmpi(pixel_type_string, "GBRP16")) {
+      vi.pixel_type = VideoInfo::CS_GBRP16;
     } else {
-      env->ThrowError("BlankClip: pixel_type must be \"RGB32\", \"RGB24\", \"YV12\", \"YV24\", \"YV16\", \"Y8\", \n"\
+      env->ThrowError("BlankClip: pixel_type must be \"RGB48\", \"RGB64\", \"RGB32\", \"RGB24\", \"YV12\", \"YV24\", \"YV16\", \"Y8\", \n"\
       "\"YUV420P16\",\"YUV422P16\",\"YUV444P16\",\"Y16\",\"YUV420PS\",\"YUV422PS\",\"YUV444PS\",\"Y32\",\n"\
       "\"YV411\" or \"YUY2\"");
     }

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -435,6 +435,8 @@ Code Bits Remark      Classic_RGB  YUV  YUY2  Y_Grey Planar_RGB*
 //  CS_YV12  = 1<<3  Reserved
 //  CS_I420  = 1<<4  Reserved
     CS_RAW32 = 1<<5 | CS_INTERLEAVED,
+    CS_BGR48 = 1<<6 | CS_BGR | CS_INTERLEAVED | CS_Sample_Bits_16,
+    CS_BGR64 = 1<<7 | CS_BGR | CS_INTERLEAVED | CS_Sample_Bits_16,
 
 //  YV12 must be 0xA000008 2.5 Baked API will see all new planar as YV12
 //  I420 must be 0xA000010
@@ -487,7 +489,12 @@ Code Bits Remark      Classic_RGB  YUV  YUY2  Y_Grey Planar_RGB*
     // grey 32
     CS_Y32 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_32,                                         // Y   4:0:0 32bit samples
 
-    // todo: rgb
+    // planar rgb
+    CS_GBRP = CS_PLANAR | CS_BGR | CS_Sample_Bits_8,                                                          // Planar RGB
+    CS_GBRP10 = CS_PLANAR | CS_BGR | CS_Sample_Bits_10,                                                       // Planar RGB 10-bit
+    CS_GBRP12 = CS_PLANAR | CS_BGR | CS_Sample_Bits_12,                                                       // Planar RGB 12-bit
+    CS_GBRP14 = CS_PLANAR | CS_BGR | CS_Sample_Bits_14,                                                       // Planar RGB 14-bit
+    CS_GBRP16 = CS_PLANAR | CS_BGR | CS_Sample_Bits_16                                                       // Planar RGB 16-bit
 
 /*
 

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -417,6 +417,9 @@ Code Bits Remark      Classic_RGB  YUV  YUY2  Y_Grey Planar_RGB*
 
     CS_Sample_Bits_Mask  = 7 << CS_Shift_Sample_Bits,
     CS_Sample_Bits_8     = 0 << CS_Shift_Sample_Bits,
+    CS_Sample_Bits_10    = 5 << CS_Shift_Sample_Bits,
+    CS_Sample_Bits_12    = 6 << CS_Shift_Sample_Bits,
+    CS_Sample_Bits_14    = 7 << CS_Shift_Sample_Bits,
     CS_Sample_Bits_16    = 1 << CS_Shift_Sample_Bits,
     CS_Sample_Bits_32    = 2 << CS_Shift_Sample_Bits,
 
@@ -448,12 +451,33 @@ Code Bits Remark      Classic_RGB  YUV  YUY2  Y_Grey Planar_RGB*
 
     //-------------------------
     // AVS16: new planar constants go live! Experimental PF 160613 
+    CS_YUV444P10 = CS_PLANAR | CS_YUV | CS_Sample_Bits_10 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_1, // YUV 4:4:4 10bit samples
+    CS_YUV422P10 = CS_PLANAR | CS_YUV | CS_Sample_Bits_10 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_2, // YUV 4:2:2 10bit samples
+    CS_YUV420P10 = CS_PLANAR | CS_YUV | CS_Sample_Bits_10 | CS_VPlaneFirst | CS_Sub_Height_2 | CS_Sub_Width_2, // YUV 4:2:0 10bit samples
+
+    // grey 10
+    CS_Y10 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_10,                                          // Y   4:0:0 10bit samples
+
+    CS_YUV444P12 = CS_PLANAR | CS_YUV | CS_Sample_Bits_12 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_1, // YUV 4:4:4 12bit samples
+    CS_YUV422P12 = CS_PLANAR | CS_YUV | CS_Sample_Bits_12 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_2, // YUV 4:2:2 12bit samples
+    CS_YUV420P12 = CS_PLANAR | CS_YUV | CS_Sample_Bits_12 | CS_VPlaneFirst | CS_Sub_Height_2 | CS_Sub_Width_2, // YUV 4:2:0 12bit samples
+
+    // grey 12
+    CS_Y12 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_12,                                          // Y   4:0:0 12bit samples
+
+    CS_YUV444P14 = CS_PLANAR | CS_YUV | CS_Sample_Bits_14 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_1, // YUV 4:4:4 14bit samples
+    CS_YUV422P14 = CS_PLANAR | CS_YUV | CS_Sample_Bits_14 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_2, // YUV 4:2:2 14bit samples
+    CS_YUV420P14 = CS_PLANAR | CS_YUV | CS_Sample_Bits_14 | CS_VPlaneFirst | CS_Sub_Height_2 | CS_Sub_Width_2, // YUV 4:2:0 14bit samples
+
+    // grey 14
+    CS_Y14 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_14,                                          // Y   4:0:0 14bit samples
+
     CS_YUV444P16 = CS_PLANAR | CS_YUV | CS_Sample_Bits_16 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_1, // YUV 4:4:4 16bit samples
     CS_YUV422P16 = CS_PLANAR | CS_YUV | CS_Sample_Bits_16 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_2, // YUV 4:2:2 16bit samples
     CS_YUV420P16 = CS_PLANAR | CS_YUV | CS_Sample_Bits_16 | CS_VPlaneFirst | CS_Sub_Height_2 | CS_Sub_Width_2, // YUV 4:2:0 16bit samples
 
     // grey 16
-    CS_Y16 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_16,                                      // Y   4:0:0 16bit samples
+    CS_Y16 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_16,                                          // Y   4:0:0 16bit samples
 
     // 32 bit samples (float)
     CS_YUV444PS = CS_PLANAR | CS_YUV | CS_Sample_Bits_32 | CS_VPlaneFirst | CS_Sub_Height_1 | CS_Sub_Width_1, // YUV 4:4:4 32bit samples
@@ -461,7 +485,7 @@ Code Bits Remark      Classic_RGB  YUV  YUY2  Y_Grey Planar_RGB*
     CS_YUV420PS = CS_PLANAR | CS_YUV | CS_Sample_Bits_32 | CS_VPlaneFirst | CS_Sub_Height_2 | CS_Sub_Width_2, // YUV 4:2:0 32bit samples
 
     // grey 32
-    CS_Y32 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_32,                                      // Y   4:0:0 32bit samples
+    CS_Y32 = CS_PLANAR | CS_INTERLEAVED | CS_YUV | CS_Sample_Bits_32,                                         // Y   4:0:0 32bit samples
 
     // todo: rgb
 

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -117,6 +117,8 @@ enum {
   //  AVS_CS_YV12  = 1<<3  Reserved
   //  AVS_CS_I420  = 1<<4  Reserved
   AVS_CS_RAW32 = 1<<5 | AVS_CS_INTERLEAVED,
+  AVS_CS_BGR48 = 1<<6 | AVS_CS_BGR | AVS_CS_INTERLEAVED | AVS_CS_SAMPLE_BITS_16,
+  AVS_CS_BGR64 = 1<<7 | AVS_CS_BGR | AVS_CS_INTERLEAVED | AVS_CS_SAMPLE_BITS_16,
 
   AVS_CS_YV24  = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1,  // YVU 4:4:4 planar
   AVS_CS_YV16  = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_2,  // YVU 4:2:2 planar
@@ -165,9 +167,14 @@ enum {
   // AVS_CS_YV96  = AVS_CS_YUV444PS,
 
   // grey 32
-  AVS_CS_Y32 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32                                                  // Y   4:0:0 32bit samples
+  AVS_CS_Y32 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32,                                                  // Y   4:0:0 32bit samples
 
-  // todo: rgb
+  // planar rgb
+  AVS_CS_GBRP = AVS_CS_PLANAR | AVS_CS_BGR | AVS_CS_SAMPLE_BITS_8,                                                                       // Planar RGB
+  AVS_CS_GBRP10 = AVS_CS_PLANAR | AVS_CS_BGR | AVS_CS_SAMPLE_BITS_10,                                                                    // Planar RGB 10-bit
+  AVS_CS_GBRP12 = AVS_CS_PLANAR | AVS_CS_BGR | AVS_CS_SAMPLE_BITS_12,                                                                    // Planar RGB 12-bit
+  AVS_CS_GBRP14 = AVS_CS_PLANAR | AVS_CS_BGR | AVS_CS_SAMPLE_BITS_14,                                                                    // Planar RGB 14-bit
+  AVS_CS_GBRP16 = AVS_CS_PLANAR | AVS_CS_BGR | AVS_CS_SAMPLE_BITS_16                                                                    // Planar RGB 16-bit
 
 };
 
@@ -304,6 +311,10 @@ AVSC_INLINE int avs_is_yuv(const AVS_VideoInfo * p)
 AVSC_INLINE int avs_is_yuy2(const AVS_VideoInfo * p) 
         { return (p->pixel_type & AVS_CS_YUY2) == AVS_CS_YUY2; }  
 
+AVSC_API(int, avs_is_rgb48)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_rgb64)(const AVS_VideoInfo * p);
+
 AVSC_API(int, avs_is_yv24)(const AVS_VideoInfo * p);
 
 AVSC_API(int, avs_is_yv16)(const AVS_VideoInfo * p);
@@ -353,6 +364,16 @@ AVSC_API(int, avs_is_yuv422ps)(const AVS_VideoInfo * p);
 AVSC_API(int, avs_is_yuv420ps)(const AVS_VideoInfo * p);
 
 AVSC_API(int, avs_is_y32)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_gbrp)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_gbrp10)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_gbrp12)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_gbrp14)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_gbrp16)(const AVS_VideoInfo * p);
 
 AVSC_INLINE int avs_is_property(const AVS_VideoInfo * p, int property) 
         { return ((p->image_type & property)==property ); }
@@ -839,6 +860,8 @@ struct AVS_Library {
   AVSC_DECLARE_FUNC(avs_vsprintf);
 
   AVSC_DECLARE_FUNC(avs_get_error);
+  AVSC_DECLARE_FUNC(avs_is_rgb48);
+  AVSC_DECLARE_FUNC(avs_is_rgb64);
   AVSC_DECLARE_FUNC(avs_is_yv24);
   AVSC_DECLARE_FUNC(avs_is_yv16);
   AVSC_DECLARE_FUNC(avs_is_yv12);
@@ -864,6 +887,11 @@ struct AVS_Library {
   AVSC_DECLARE_FUNC(avs_is_yuv422ps);
   AVSC_DECLARE_FUNC(avs_is_yuv420ps);
   AVSC_DECLARE_FUNC(avs_is_y32);
+  AVSC_DECLARE_FUNC(avs_is_gbrp);
+  AVSC_DECLARE_FUNC(avs_is_gbrp10);
+  AVSC_DECLARE_FUNC(avs_is_gbrp12);
+  AVSC_DECLARE_FUNC(avs_is_gbrp14);
+  AVSC_DECLARE_FUNC(avs_is_gbrp16);
   AVSC_DECLARE_FUNC(avs_is_color_space);
 
   AVSC_DECLARE_FUNC(avs_get_plane_width_subsampling);
@@ -938,6 +966,8 @@ AVSC_INLINE AVS_Library * avs_load_library() {
   AVSC_LOAD_FUNC(avs_vsprintf);
 
   AVSC_LOAD_FUNC(avs_get_error);
+  AVSC_LOAD_FUNC(avs_is_rgb48);
+  AVSC_LOAD_FUNC(avs_is_rgb64);
   AVSC_LOAD_FUNC(avs_is_yv24);
   AVSC_LOAD_FUNC(avs_is_yv16);
   AVSC_LOAD_FUNC(avs_is_yv12);
@@ -963,6 +993,11 @@ AVSC_INLINE AVS_Library * avs_load_library() {
   AVSC_LOAD_FUNC(avs_is_yuv422ps);
   AVSC_LOAD_FUNC(avs_is_yuv420ps);
   AVSC_LOAD_FUNC(avs_is_y32);
+  AVSC_LOAD_FUNC(avs_is_gbrp);
+  AVSC_LOAD_FUNC(avs_is_gbrp10);
+  AVSC_LOAD_FUNC(avs_is_gbrp12);
+  AVSC_LOAD_FUNC(avs_is_gbrp14);
+  AVSC_LOAD_FUNC(avs_is_gbrp16);
   AVSC_LOAD_FUNC(avs_is_color_space);
 
   AVSC_LOAD_FUNC(avs_get_plane_width_subsampling);

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -99,6 +99,9 @@ enum {AVS_CS_BGR = 1<<28,
 
       AVS_CS_SAMPLE_BITS_MASK  = 7 << AVS_CS_SHIFT_SAMPLE_BITS,
       AVS_CS_SAMPLE_BITS_8     = 0 << AVS_CS_SHIFT_SAMPLE_BITS,
+      AVS_CS_SAMPLE_BITS_10    = 5 << AVS_CS_SHIFT_SAMPLE_BITS,
+      AVS_CS_SAMPLE_BITS_12    = 6 << AVS_CS_SHIFT_SAMPLE_BITS,
+      AVS_CS_SAMPLE_BITS_14    = 7 << AVS_CS_SHIFT_SAMPLE_BITS,
       AVS_CS_SAMPLE_BITS_16    = 1 << AVS_CS_SHIFT_SAMPLE_BITS,
       AVS_CS_SAMPLE_BITS_32    = 2 << AVS_CS_SHIFT_SAMPLE_BITS,
 
@@ -122,17 +125,38 @@ enum {
   AVS_CS_IYUV  = AVS_CS_I420,
   AVS_CS_YV411 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_4,  // YVU 4:1:1 planar
   AVS_CS_YUV9  = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_4 | AVS_CS_SUB_WIDTH_4,  // YVU 4:1:0 planar
-  AVS_CS_Y8    = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8,                                              // Y   4:0:0 planar
+  AVS_CS_Y8    = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8,                                             // Y   4:0:0 planar
 
   //-------------------------
   // AVS16: new planar constants go live! Experimental PF 160613
+  AVS_CS_YUV444P10 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_10 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1, // YUV 4:4:4 10bit samples
+  AVS_CS_YUV422P10 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_10 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:2 10bit samples
+  AVS_CS_YUV420P10 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_10 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_2 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:0 10bit samples
+
+  // grey 10
+  AVS_CS_Y10 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_10,                                                 // Y   4:0:0 10bit samples
+
+  AVS_CS_YUV444P12 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_12 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1, // YUV 4:4:4 12bit samples
+  AVS_CS_YUV422P12 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_12 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:2 12bit samples
+  AVS_CS_YUV420P12 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_12 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_2 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:0 12bit samples
+
+  // grey 12
+  AVS_CS_Y12 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_12,                                                 // Y   4:0:0 12bit samples
+
+  AVS_CS_YUV444P14 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_14 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1, // YUV 4:4:4 14bit samples
+  AVS_CS_YUV422P14 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_14 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:2 14bit samples
+  AVS_CS_YUV420P14 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_14 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_2 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:0 14bit samples
+
+  // grey 14
+  AVS_CS_Y14 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_14,                                                 // Y   4:0:0 14bit samples
+
   AVS_CS_YUV444P16 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1, // YUV 4:4:4 16bit samples
   AVS_CS_YUV422P16 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:2 16bit samples
   AVS_CS_YUV420P16 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_2 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:0 16bit samples
   // no short naming style. AVS_CS_YV24->AVS_CS_YV48 = AVS_CS_YUV444P16 ok. but YV12->YV24? no-no.
 
   // grey 16
-  AVS_CS_Y16 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16,                                      // Y   4:0:0 16bit samples
+  AVS_CS_Y16 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16,                                                 // Y   4:0:0 16bit samples
 
   // 32 bit samples (float)
   AVS_CS_YUV444PS = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1, // YUV 4:4:4 32bit samples
@@ -141,7 +165,7 @@ enum {
   // AVS_CS_YV96  = AVS_CS_YUV444PS,
 
   // grey 32
-  AVS_CS_Y32 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32                                      // Y   4:0:0 32bit samples
+  AVS_CS_Y32 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32                                                  // Y   4:0:0 32bit samples
 
   // todo: rgb
 
@@ -289,6 +313,30 @@ AVSC_API(int, avs_is_yv12)(const AVS_VideoInfo * p) ;
 AVSC_API(int, avs_is_yv411)(const AVS_VideoInfo * p);
 
 AVSC_API(int, avs_is_y8)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv444p10)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv422p10)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv420p10)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_y10)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv444p12)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv422p12)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv420p12)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_y12)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv444p14)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv422p14)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv420p14)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_y14)(const AVS_VideoInfo * p);
 
 AVSC_API(int, avs_is_yuv444p16)(const AVS_VideoInfo * p);
 
@@ -796,6 +844,18 @@ struct AVS_Library {
   AVSC_DECLARE_FUNC(avs_is_yv12);
   AVSC_DECLARE_FUNC(avs_is_yv411);
   AVSC_DECLARE_FUNC(avs_is_y8);
+  AVSC_DECLARE_FUNC(avs_is_yuv444p10);
+  AVSC_DECLARE_FUNC(avs_is_yuv422p10);
+  AVSC_DECLARE_FUNC(avs_is_yuv420p10);
+  AVSC_DECLARE_FUNC(avs_is_y10);
+  AVSC_DECLARE_FUNC(avs_is_yuv444p12);
+  AVSC_DECLARE_FUNC(avs_is_yuv422p12);
+  AVSC_DECLARE_FUNC(avs_is_yuv420p12);
+  AVSC_DECLARE_FUNC(avs_is_y12);
+  AVSC_DECLARE_FUNC(avs_is_yuv444p14);
+  AVSC_DECLARE_FUNC(avs_is_yuv422p14);
+  AVSC_DECLARE_FUNC(avs_is_yuv420p14);
+  AVSC_DECLARE_FUNC(avs_is_y14);
   AVSC_DECLARE_FUNC(avs_is_yuv444p16);
   AVSC_DECLARE_FUNC(avs_is_yuv422p16);
   AVSC_DECLARE_FUNC(avs_is_yuv420p16);
@@ -883,6 +943,18 @@ AVSC_INLINE AVS_Library * avs_load_library() {
   AVSC_LOAD_FUNC(avs_is_yv12);
   AVSC_LOAD_FUNC(avs_is_yv411);
   AVSC_LOAD_FUNC(avs_is_y8);
+  AVSC_LOAD_FUNC(avs_is_yuv444p10);
+  AVSC_LOAD_FUNC(avs_is_yuv422p10);
+  AVSC_LOAD_FUNC(avs_is_yuv420p10);
+  AVSC_LOAD_FUNC(avs_is_y10);
+  AVSC_LOAD_FUNC(avs_is_yuv444p12);
+  AVSC_LOAD_FUNC(avs_is_yuv422p12);
+  AVSC_LOAD_FUNC(avs_is_yuv420p12);
+  AVSC_LOAD_FUNC(avs_is_y12);
+  AVSC_LOAD_FUNC(avs_is_yuv444p14);
+  AVSC_LOAD_FUNC(avs_is_yuv422p14);
+  AVSC_LOAD_FUNC(avs_is_yuv420p14);
+  AVSC_LOAD_FUNC(avs_is_y14);
   AVSC_LOAD_FUNC(avs_is_yuv444p16);
   AVSC_LOAD_FUNC(avs_is_yuv422p16);
   AVSC_LOAD_FUNC(avs_is_yuv420p16);

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -308,8 +308,8 @@ AVSC_INLINE int avs_is_rgb32(const AVS_VideoInfo * p)
 AVSC_INLINE int avs_is_yuv(const AVS_VideoInfo * p) 
         { return !!(p->pixel_type&AVS_CS_YUV ); }
 
-AVSC_INLINE int avs_is_yuy2(const AVS_VideoInfo * p) 
-        { return (p->pixel_type & AVS_CS_YUY2) == AVS_CS_YUY2; }  
+AVSC_INLINE int avs_is_yuy2(const AVS_VideoInfo * p)
+        { return (p->pixel_type & AVS_CS_YUY2) == AVS_CS_YUY2; }
 
 AVSC_API(int, avs_is_rgb48)(const AVS_VideoInfo * p);
 
@@ -375,24 +375,24 @@ AVSC_API(int, avs_is_gbrp14)(const AVS_VideoInfo * p);
 
 AVSC_API(int, avs_is_gbrp16)(const AVS_VideoInfo * p);
 
-AVSC_INLINE int avs_is_property(const AVS_VideoInfo * p, int property) 
+AVSC_INLINE int avs_is_property(const AVS_VideoInfo * p, int property)
         { return ((p->image_type & property)==property ); }
 
-AVSC_INLINE int avs_is_planar(const AVS_VideoInfo * p) 
+AVSC_INLINE int avs_is_planar(const AVS_VideoInfo * p)
         { return !!(p->pixel_type & AVS_CS_PLANAR); }
 
 AVSC_API(int, avs_is_color_space)(const AVS_VideoInfo * p, int c_space);
-        
-AVSC_INLINE int avs_is_field_based(const AVS_VideoInfo * p) 
+
+AVSC_INLINE int avs_is_field_based(const AVS_VideoInfo * p)
         { return !!(p->image_type & AVS_IT_FIELDBASED); }
 
-AVSC_INLINE int avs_is_parity_known(const AVS_VideoInfo * p) 
+AVSC_INLINE int avs_is_parity_known(const AVS_VideoInfo * p)
         { return ((p->image_type & AVS_IT_FIELDBASED)&&(p->image_type & (AVS_IT_BFF | AVS_IT_TFF))); }
 
-AVSC_INLINE int avs_is_bff(const AVS_VideoInfo * p) 
+AVSC_INLINE int avs_is_bff(const AVS_VideoInfo * p)
         { return !!(p->image_type & AVS_IT_BFF); }
 
-AVSC_INLINE int avs_is_tff(const AVS_VideoInfo * p) 
+AVSC_INLINE int avs_is_tff(const AVS_VideoInfo * p)
         { return !!(p->image_type & AVS_IT_TFF); }
 
 AVSC_API(int, avs_get_plane_width_subsampling)(const AVS_VideoInfo * p, int plane);

--- a/plugins/ConvertStacked/ConvertStacked.cpp
+++ b/plugins/ConvertStacked/ConvertStacked.cpp
@@ -134,13 +134,41 @@ class ConvertFromStacked : public GenericVideoFilter
 {
 public:
 
-    ConvertFromStacked::ConvertFromStacked(PClip src, IScriptEnvironment* env) : GenericVideoFilter(src)
+    ConvertFromStacked::ConvertFromStacked(PClip src, int bits, IScriptEnvironment* env) : GenericVideoFilter(src)
     {
-        if (vi.IsYV12()) vi.pixel_type = VideoInfo::CS_YUV420P16;
-        else if (vi.IsYV16()) vi.pixel_type = VideoInfo::CS_YUV422P16;
-        else if (vi.IsYV24()) vi.pixel_type = VideoInfo::CS_YUV444P16;
-        else if (vi.IsY8()) vi.pixel_type = VideoInfo::CS_Y16;
-        else env->ThrowError("ConvertFromStacked: Input stacked clip must be YV12, YV16, YV24 or Y8");
+        if (bits == 10 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P10;
+        else if (bits == 10 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P10;
+        else if (bits == 10 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P10;
+        else if (bits == 10 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y10;
+        else if (bits == 12 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P12;
+        else if (bits == 12 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P12;
+        else if (bits == 12 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P12;
+        else if (bits == 12 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y12;
+        else if (bits == 14 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P14;
+        else if (bits == 14 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P14;
+        else if (bits == 14 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P14;
+        else if (bits == 14 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y14;
+        else if (bits == 16 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P16;
+        else if (bits == 16 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P16;
+        else if (bits == 16 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P16;
+        else if (bits == 16 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y16;
+        else env->ThrowError("ConvertStackedToNative: Input stacked clip must be YV12, YV16, YV24 or Y8");
 
         vi.height = vi.height >> 1; // div 2 non stacked
 
@@ -210,7 +238,9 @@ public:
     static AVSValue __cdecl ConvertFromStacked::Create(AVSValue args, void*, IScriptEnvironment* env)
     {
         PClip clip = args[0].AsClip();
-        return new ConvertFromStacked(clip, env);
+        int bits = args[1].AsInt(16);
+
+        return new ConvertFromStacked(clip, bits, env);
     }
 };
 
@@ -219,15 +249,43 @@ class ConvertFromDoubleWidth : public GenericVideoFilter
 {
 public:
 
-    ConvertFromDoubleWidth(PClip src, IScriptEnvironment* env) : GenericVideoFilter(src)
+    ConvertFromDoubleWidth(PClip src, int bits, IScriptEnvironment* env) : GenericVideoFilter(src)
     {
         if (vi.RowSize(PLANAR_U) % 2)
             env->ThrowError("ConvertFromDoubleWidth: Input clip's chroma width must be even.");
 
-        if (vi.IsYV12()) vi.pixel_type = VideoInfo::CS_YUV420P16;
-        else if (vi.IsYV16()) vi.pixel_type = VideoInfo::CS_YUV422P16;
-        else if (vi.IsYV24()) vi.pixel_type = VideoInfo::CS_YUV444P16;
-        else if (vi.IsY8()) vi.pixel_type = VideoInfo::CS_Y16;
+        if (bits == 10 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P10;
+        else if (bits == 10 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P10;
+        else if (bits == 10 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P10;
+        else if (bits == 10 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y10;
+        else if (bits == 12 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P12;
+        else if (bits == 12 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P12;
+        else if (bits == 12 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P12;
+        else if (bits == 12 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y12;
+        else if (bits == 14 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P14;
+        else if (bits == 14 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P14;
+        else if (bits == 14 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P14;
+        else if (bits == 14 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y14;
+        else if (bits == 16 && vi.IsYV12())
+            vi.pixel_type = VideoInfo::CS_YUV420P16;
+        else if (bits == 16 && vi.IsYV16())
+            vi.pixel_type = VideoInfo::CS_YUV422P16;
+        else if (bits == 16 && vi.IsYV24())
+            vi.pixel_type = VideoInfo::CS_YUV444P16;
+        else if (bits == 16 && vi.IsY8())
+            vi.pixel_type = VideoInfo::CS_Y16;
         else env->ThrowError("ConvertFromDoubleWidth: Input double width clip must be YV12, YV16, YV24 or Y8");
 
         vi.width /= 2;
@@ -247,7 +305,9 @@ public:
     static AVSValue __cdecl Create(AVSValue args, void*, IScriptEnvironment* env)
     {
         PClip clip = args[0].AsClip();
-        return new ConvertFromDoubleWidth(clip, env);
+        int bits = args[1].AsInt(16);
+
+        return new ConvertFromDoubleWidth(clip, bits, env);
     }
 };
 
@@ -289,9 +349,9 @@ static const AVS_Linkage * AVS_linkage = 0;
 extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(IScriptEnvironment* env, const AVS_Linkage* const vectors) {
     AVS_linkage = vectors;
 
-    env->AddFunction("ConvertFromStacked", "c", ConvertFromStacked::Create, 0);
+    env->AddFunction("ConvertFromStacked", "c[bits]i", ConvertFromStacked::Create, 0);
     env->AddFunction("ConvertToStacked", "c", ConvertToStacked::Create, 0);
-    env->AddFunction("ConvertFromDoubleWidth", "c", ConvertFromDoubleWidth::Create, 0);
+    env->AddFunction("ConvertFromDoubleWidth", "c[bits]i", ConvertFromDoubleWidth::Create, 0);
     env->AddFunction("ConvertToDoubleWidth", "c", ConvertToDoubleWidth::Create, 0);
 
     return "`ConvertStacked' Stacked format conversion for 16-bit formats.";


### PR DESCRIPTION
This is very preliminary, because I honestly don't know how correct a couple of pieces (CS_Shift_Sample_Bits_\*, CS_Sample_Bits_\*) here are, and using anything except 8 or 16 causes packet size issues in FFmpeg (one I've updated with the same header updates and the right additions for 10/12/14 in libavformat/avisynth.c).  Considering the output changes just by altering the ``vi.height = vi.height >> 1`` in ConvertFromStacked, I'm going to assume that this is probably a simple fix, but I'm terrible with bit operators.

ConvertFromStacked gets a bits= argument that allows the user to select a target bit depth.  This actually makes me think the enum additions may be correct, since telling f3kdb to output 14-bit but leaving ConvertFromStacked on its default (16-bits) *does* result in an almost-correct image.  But trying to output as 14-bit itself causes a bunch of:

>[rawvideo @ 03344d20] Invalid buffer size, packet size 75264 < expected frame_size 150528
Error while decoding stream #0:0: Invalid argument

in ffmpeg, followed by a crash.