### PR TITLE
Install pkg-config file if is builded on unix system

### DIFF
--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -146,6 +146,8 @@ set(version_bugfix ${CMAKE_MATCH_1})
 set(AVS_VERSION "${version_major}.${version_minor}.${version_bugfix}")
 
 set(AVSPREFIX "${CMAKE_INSTALL_PREFIX}")
+get_target_property(LIB_NAME AvsCore OUTPUT_NAME)
+set(LIBS "-l${LIB_NAME}")
 CONFIGURE_FILE("avisynth.pc.in" "avisynth.pc" @ONLY)
 
 set(RUNTIME_INSTALL_DIR bin CACHE STRING "Install location of Windows DLLs")
@@ -159,3 +161,6 @@ INSTALL(TARGETS AvsCore
 
 INSTALL(DIRECTORY "include/"
         DESTINATION "${CMAKE_INSTALL_PREFIX}/include/avisynth")
+
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/avisynth.pc
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/pkgconfig")

--- a/avs_core/avisynth.pc.in
+++ b/avs_core/avisynth.pc.in
@@ -1,11 +1,11 @@
 prefix=@AVSPREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+includedir=${prefix}/include/avisynth
 
 Name: AviSynth+
 Description: A powerful nonlinear scripting language for video.
 Version: @AVS_VERSION@
 
 Libs: -L${libdir} @LIBS@
-Cflags: -I${includedir} @CFLAGS@
+Cflags: -I${includedir}


### PR DESCRIPTION
add missing install rule for install the pkg-config file

~~because i'm not sure if is useful in windows, only install the file if is builded on unix systems (bsd(?) & linux & macos)~~