### PR TITLE
Use cmake GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ if(CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING "Reset the configurations to what we need" FORCE)
 endif()
 
+include(GNUInstallDirs)
+
 IF( MSVC )  # Check for Visual Studio
 
   #1800      = VS 12.0 (v120 toolset)
@@ -48,7 +50,7 @@ IF( MSVC )  # Check for Visual Studio
 
   IF(MSVC_IDE)
     message("Reported CMAKE_GENERATOR_TOOLSET is: ${CMAKE_GENERATOR_TOOLSET}")
-    
+
     # For LLVM Clang installed separately, specify llvm or LLVM
     # Since Visual Studio 2019 v16.4, LLVM 9.0 is integrated, for this use Toolset: ClangCL
     IF(CMAKE_GENERATOR_TOOLSET STREQUAL "LLVM" OR CMAKE_GENERATOR_TOOLSET STREQUAL "llvm" OR CMAKE_GENERATOR_TOOLSET STREQUAL "ClangCL")
@@ -68,7 +70,7 @@ IF( MSVC )  # Check for Visual Studio
       message("May not work, try LLVM")
       set(CLANG_IN_VS "1")
     ENDIF()
-  
+
     # We want our project to also run on Windows XP
     # Not for LLVM: Clang stopped XP support in 2016
     # 1900 (VS2015) is not supported but we leave here
@@ -106,7 +108,7 @@ IF( MSVC )  # Check for Visual Studio
   ENDIF()
   # Prevent VC++ from complaining about not using MS-specific functions
   add_definitions("/D _CRT_SECURE_NO_WARNINGS /D _SECURE_SCL=0")
-  
+
   # Enable CRT heap debugging - only effective in debug builds
   add_definitions("/D _CRTDBG_MAP_ALLOC")
 

--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -144,23 +144,17 @@ set(version_minor ${CMAKE_MATCH_1})
 string(REGEX MATCH "AVS_BUGFIX_VER    ([0-9]*)" _ ${versioning})
 set(version_bugfix ${CMAKE_MATCH_1})
 set(AVS_VERSION "${version_major}.${version_minor}.${version_bugfix}")
-
-set(AVSPREFIX "${CMAKE_INSTALL_PREFIX}")
 get_target_property(LIB_NAME AvsCore OUTPUT_NAME)
 set(LIBS "-l${LIB_NAME}")
 CONFIGURE_FILE("avisynth.pc.in" "avisynth.pc" @ONLY)
 
-set(RUNTIME_INSTALL_DIR bin CACHE STRING "Install location of Windows DLLs")
-set(LIB_INSTALL_DIR lib CACHE STRING "Install location of libraries")
-set(ARCHIVE_INSTALL_DIR lib CACHE STRING "Install location of static libraries")
-
 INSTALL(TARGETS AvsCore
-        RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/${RUNTIME_INSTALL_DIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 INSTALL(DIRECTORY "include/"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/include/avisynth")
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/avisynth")
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/avisynth.pc
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/pkgconfig")
+INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/avisynth.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/avs_core/avisynth.pc.in
+++ b/avs_core/avisynth.pc.in
@@ -1,7 +1,7 @@
-prefix=@AVSPREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include/avisynth
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@/avisynth
 
 Name: AviSynth+
 Description: A powerful nonlinear scripting language for video.

--- a/plugins/ConvertStacked/CMakeLists.txt
+++ b/plugins/ConvertStacked/CMakeLists.txt
@@ -33,4 +33,4 @@ if (MSVC_IDE)
 endif()
 
 INSTALL(TARGETS "${ProjectName}"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/avisynth")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/avisynth")

--- a/plugins/DirectShowSource/CMakeLists.txt
+++ b/plugins/DirectShowSource/CMakeLists.txt
@@ -51,4 +51,4 @@ if (MSVC_IDE)
 endif()
 
 INSTALL(TARGETS "${ProjectName}"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/avisynth")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/avisynth")

--- a/plugins/ImageSeq/CMakeLists.txt
+++ b/plugins/ImageSeq/CMakeLists.txt
@@ -46,4 +46,4 @@ if (MSVC_IDE)
 endif()
 
 INSTALL(TARGETS "${ProjectName}"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/avisynth")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/avisynth")

--- a/plugins/Shibatch/CMakeLists.txt
+++ b/plugins/Shibatch/CMakeLists.txt
@@ -43,4 +43,4 @@ if (MSVC_IDE)
 endif()
 
 INSTALL(TARGETS "${ProjectName}"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/avisynth")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/avisynth")

--- a/plugins/TimeStretch/CMakeLists.txt
+++ b/plugins/TimeStretch/CMakeLists.txt
@@ -34,4 +34,4 @@ if (MSVC_IDE)
 endif()
 
 INSTALL(TARGETS "${ProjectName}"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/avisynth")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/avisynth")

--- a/plugins/VDubFilter/CMakeLists.txt
+++ b/plugins/VDubFilter/CMakeLists.txt
@@ -39,4 +39,4 @@ if (MSVC_IDE)
 endif()
 
 INSTALL(TARGETS "${ProjectName}"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/avisynth")
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/avisynth")

--- a/plugins/VFAPIFilter/CMakeLists.txt
+++ b/plugins/VFAPIFilter/CMakeLists.txt
@@ -38,4 +38,4 @@ if (MSVC_IDE)
 endif()
 
 INSTALL(TARGETS "${ProjectName}"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/avisynth")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/avisynth")


### PR DESCRIPTION
See https://cmake.org/cmake/help/v3.8/module/GNUInstallDirs.html

This get to Linux dristribution like Gentoo can change the library, binary and header paths

For example, Gentoo uses `foo/lib` as path for 32-bit libaries and `foo/lib64` for 64-bits

Use `-DCMAKE_INSTALL_LIBDIR` `-DCMKE_INSTALL_INCLUDEDIR` and `-DCMAKE_INSTALL_BINDIR` change
the default behavior.

The use of `-DCMAKE_INSTALL_PREFIX` is untouched