### PR TITLE
Add soname/soversion in Unix libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,19 @@
 # "Visual Studio 16 2019" + LLVM 8.0 (clang) optional platform generator Win32 and x64
 CMAKE_MINIMUM_REQUIRED( VERSION 3.8.2 )
 
+# Get PROJECT_VERSION property from 'avs_core/core/version.h.in'
+file(READ "avs_core/core/version.h.in" versioning)
+string(REGEX MATCH "AVS_MAJOR_VER     ([0-9]*)" _ ${versioning})
+set(version_major ${CMAKE_MATCH_1})
+string(REGEX MATCH "AVS_MINOR_VER     ([0-9]*)" _ ${versioning})
+set(version_minor ${CMAKE_MATCH_1})
+string(REGEX MATCH "AVS_BUGFIX_VER    ([0-9]*)" _ ${versioning})
+set(version_bugfix ${CMAKE_MATCH_1})
+# Get AVISYNTH_INTERFACE_VERSION from avs_core/include/avisynth.h
+file(READ "avs_core/include/avisynth.h" versioning)
+string(REGEX MATCH "AVISYNTH_INTERFACE_VERSION = ([0-9]*)" _ ${versioning})
+set(AVISYNTH_INTERFACE_VERSION ${CMAKE_MATCH_1})
+
 option(HEADERS_ONLY "Install only the Headers" ${INSTALL_ONLY_HEADER})
 if(${INSTALL_ONLY_HEADER})
   set(INSTALL_ONLY_HEADER OFF)
@@ -18,7 +31,7 @@ include(GNUInstallDirs)
 
 if(NOT HEADERS_ONLY)
 
-  project("AviSynth+")
+  project("AviSynth+" VERSION ${version_major}.${version_minor}.${version_bugfix} LANGUAGES CXX)
 
   # Avoid uselessly linking to unused libraries
   set(CMAKE_STANDARD_LIBRARIES "" CACHE STRING "" FORCE)
@@ -195,7 +208,7 @@ if(NOT HEADERS_ONLY)
 
 else()
 
-  project(AviSynth-Headers NONE)
+  project(AviSynth-Headers VERSION ${version_major}.${version_minor}.${version_bugfix} LANGUAGES)
   message(STATUS "Install Only Headers: ON")
 
   add_library(${PROJECT_NAME} INTERFACE)

--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -9,13 +9,15 @@ else()
 endif()
 
 # Create library
-project("AvsCore")
+project("AvsCore" VERSION "${PROJECT_VERSION}" LANGUAGES CXX)
 Include("Files.cmake")
 add_library("AvsCore" SHARED ${AvsCore_Sources})
 set_target_properties("AvsCore" PROPERTIES "OUTPUT_NAME" "${CoreName}")
 if (MINGW)
   set_target_properties("AvsCore" PROPERTIES PREFIX "")
   set_target_properties("AvsCore" PROPERTIES IMPORT_PREFIX "")
+elseif(UNIX)
+  set_target_properties("AvsCore" PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${AVISYNTH_INTERFACE_VERSION})
 endif()
 
 # Automatically group source files according to directory structure
@@ -138,14 +140,6 @@ ADD_CUSTOM_TARGET(
 ADD_DEPENDENCIES("AvsCore" VersionGen)
 
 # Generate pkg-config file
-file(READ "core/version.h.in" versioning)
-string(REGEX MATCH "AVS_MAJOR_VER     ([0-9]*)" _ ${versioning})
-set(version_major ${CMAKE_MATCH_1})
-string(REGEX MATCH "AVS_MINOR_VER     ([0-9]*)" _ ${versioning})
-set(version_minor ${CMAKE_MATCH_1})
-string(REGEX MATCH "AVS_BUGFIX_VER    ([0-9]*)" _ ${versioning})
-set(version_bugfix ${CMAKE_MATCH_1})
-set(AVS_VERSION "${version_major}.${version_minor}.${version_bugfix}")
 get_target_property(LIB_NAME AvsCore OUTPUT_NAME)
 set(LIBS "-l${LIB_NAME}")
 CONFIGURE_FILE("avisynth.pc.in" "avisynth.pc" @ONLY)

--- a/avs_core/avisynth.pc.in
+++ b/avs_core/avisynth.pc.in
@@ -5,7 +5,7 @@ includedir=${exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@/avisynth
 
 Name: AviSynth+
 Description: A powerful nonlinear scripting language for video.
-Version: @AVS_VERSION@
+Version: @PROJECT_VERSION@
 
 Libs: -L${libdir} @LIBS@
 Cflags: -I${includedir}

--- a/plugins/ConvertStacked/CMakeLists.txt
+++ b/plugins/ConvertStacked/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT WIN32)
 endif()
 
 # Create library
-project(${ProjectName})
+project(${ProjectName} VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 list (APPEND SourceFiles
     "ConvertStacked.cpp"
 )

--- a/plugins/DirectShowSource/CMakeLists.txt
+++ b/plugins/DirectShowSource/CMakeLists.txt
@@ -18,7 +18,7 @@ set(DSHOWSRC_BASECLASSES_PATH "${DEFAULT_BASECLASSES_PATH}" CACHE STRING   "Fold
 set(DSHOWSRC_BASECLASSES_LIB  "${DEFAULT_BASECLASSES_LIB}"  CACHE FILEPATH "File path to the DirectShow example baseclasses precompiled static library ('strmbase.lib').")
 
 # Create library
-project(${ProjectName})
+project(${ProjectName} VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 list (APPEND SourceFiles
     "directshow_source.cpp"
     "directshow_source.h"

--- a/plugins/ImageSeq/CMakeLists.txt
+++ b/plugins/ImageSeq/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT WIN32)
 endif()
 
 # Create library
-project(${ProjectName})
+project(${ProjectName} VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 list (APPEND SourceFiles
     "ImageSeq.cpp"
     "ImageSeq.h"

--- a/plugins/Shibatch/CMakeLists.txt
+++ b/plugins/Shibatch/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT WIN32)
 endif()
 
 # Create library
-project(${ProjectName})
+project(${ProjectName} VERSION ${PROJECT_VERSION} LANGUAGES C)
 list (APPEND SourceFiles
     "dbesi0.c"
     "fft.h"

--- a/plugins/TimeStretch/CMakeLists.txt
+++ b/plugins/TimeStretch/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT WIN32)
 endif()
 
 # Create library
-project(${ProjectName})
+project(${ProjectName} VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 list (APPEND SourceFiles
     "TimeStretch.cpp"
 )

--- a/plugins/VDubFilter/CMakeLists.txt
+++ b/plugins/VDubFilter/CMakeLists.txt
@@ -6,7 +6,7 @@ set(PluginName "VDubFilter")
 set(ProjectName "Plugin${PluginName}")
 
 # Create library
-project(${ProjectName})
+project(${ProjectName} VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 list (APPEND SourceFiles
     "VDubFilter.cpp"
     "GetCPUFlags.cpp"

--- a/plugins/VFAPIFilter/CMakeLists.txt
+++ b/plugins/VFAPIFilter/CMakeLists.txt
@@ -11,7 +11,7 @@ set(DSHOWSRC_BASECLASSES_LIB CACHE FILEPATH "File path to the DirectShow example
 set(DSHOWSRC_DX_INCLUDE_PATH "C:/Program Files/Microsoft DirectX SDK (August 2009)/Include" CACHE STRING "Include folder path to the DirectX headers.")
 
 # Create library
-project(${ProjectName})
+project(${ProjectName} VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 list (APPEND SourceFiles
     "VFAPIFilter.cpp"
 )


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Soname
https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html

Also add `PROJECT_VERSION` in the `project()` function  with moving some code from `avs_core\CMakeLists.txt` to main `CMakeLists`

the SONAME/SOVERSION "rename" the libarary to `libavistnth.so.X.X.X` and add symlink to `libavisynth.so.X` and `libavisynth.so`

~~~
└───╼  ls libavisynth.so*
lrwxrwxrwx 1 sl1pkn07 users       16 mar 19 02:00 libavisynth.so -> libavisynth.so.3
lrwxrwxrwx 1 sl1pkn07 users       20 mar 19 02:00 libavisynth.so.3 -> libavisynth.so.3.5.0
-rwxr-xr-x 1 sl1pkn07 users 10916424 mar 19 02:00 libavisynth.so.3.5.0
└───╼  objdump -p libavisynth.so.3.5.0 | grep SONAME
  SONAME               libavisynth.so.3
└───╼  readelf -d libavisynth.so.3.5.0 | grep SONAME
 0x000000000000000e (SONAME)             Nombre-so de la biblioteca: [libavisynth.so.3]
~~~