### PR TITLE
Remove the force override to XP toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,24 +78,27 @@ if(NOT HEADERS_ONLY)
         set(CLANG_IN_VS "1")
       ENDIF()
 
-      # We want our project to also run on Windows XP
-      # Not for LLVM: Clang stopped XP support in 2016
-      # 1900 (VS2015) is not supported but we leave here
-      IF(MSVC_VERSION VERSION_LESS 1910 )
-        IF(NOT CLANG_IN_VS STREQUAL "1")
-          set(CMAKE_GENERATOR_TOOLSET "v140_xp" CACHE STRING "The compiler toolset to use for Visual Studio." FORCE) # VS2015
-          # https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics
-          message("CMAKE_GENERATOR_TOOLSET is forced to: ${CMAKE_GENERATOR_TOOLSET}")
-          add_definitions("/Zc:threadSafeInit-")
-      ENDIF()
-      ELSE()
-        IF(NOT CLANG_IN_VS STREQUAL "1")
-          set(CMAKE_GENERATOR_TOOLSET "v141_xp" CACHE STRING "The compiler toolset to use for Visual Studio." FORCE) # VS2017, also choosable for VS2019
-          # https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics
-          message("CMAKE_GENERATOR_TOOLSET is forced to: ${CMAKE_GENERATOR_TOOLSET}")
-          add_definitions("/Zc:threadSafeInit-")
+      option(WINXP_SUPPORT "Make binaries compatible with Windows XP and Vista" OFF)
+      if(WINXP_SUPPORT)
+        # We want our project to also run on Windows XP
+        # Not for LLVM: Clang stopped XP support in 2016
+        # 1900 (VS2015) is not supported but we leave here
+        IF(MSVC_VERSION VERSION_LESS 1910 )
+          IF(NOT CLANG_IN_VS STREQUAL "1")
+            set(CMAKE_GENERATOR_TOOLSET "v140_xp" CACHE STRING "The compiler toolset to use for Visual Studio." FORCE) # VS2015
+            # https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics
+            message("CMAKE_GENERATOR_TOOLSET is forced to: ${CMAKE_GENERATOR_TOOLSET}")
+            add_definitions("/Zc:threadSafeInit-")
+          ENDIF()
+        ELSE()
+          IF(NOT CLANG_IN_VS STREQUAL "1")
+            set(CMAKE_GENERATOR_TOOLSET "v141_xp" CACHE STRING "The compiler toolset to use for Visual Studio." FORCE) # VS2017, also choosable for VS2019
+            # https://connect.microsoft.com/VisualStudio/feedback/details/1789709/visual-c-2015-runtime-broken-on-windows-server-2003-c-11-magic-statics
+            message("CMAKE_GENERATOR_TOOLSET is forced to: ${CMAKE_GENERATOR_TOOLSET}")
+            add_definitions("/Zc:threadSafeInit-")
+          ENDIF()
         ENDIF()
-      ENDIF()
+      endif()
     ENDIF()
 
     IF(CLANG_IN_VS STREQUAL "1")


### PR DESCRIPTION
Both Windows XP and the vc141_xp toolchain have been deprecated for a long time. It requires manual installation an extra component in Visual Studio. This force override simply breaks normal users who only install default toolchain which does not have vc141_xp.

We should not force the user to use deprecated unmaintained tools. Whoever need to build binary for XP should understand what they are doing. They should be able to install those tools by themselves, and specify `CMAKE_GENERATOR_TOOLSET`.