### PR TITLE
Silence cmake warning about gnuinstaldirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,11 @@ if(${INSTALL_ONLY_HEADER})
   set(INSTALL_ONLY_HEADER OFF)
 endif()
 
-include(GNUInstallDirs)
-
 if(NOT HEADERS_ONLY)
 
   project("AviSynth+" VERSION ${version_major}.${version_minor}.${version_bugfix} LANGUAGES CXX)
+
+  include(GNUInstallDirs)
 
   # Avoid uselessly linking to unused libraries
   set(CMAKE_STANDARD_LIBRARIES "" CACHE STRING "" FORCE)
@@ -215,6 +215,8 @@ else()
   add_library(${PROJECT_NAME} INTERFACE)
   target_include_directories(${PROJECT_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/avs_core/include")
   add_library(AviSynth::Headers ALIAS ${PROJECT_NAME})
+
+  include(GNUInstallDirs)
 
   install(
           FILES ${CMAKE_CURRENT_SOURCE_DIR}/avs_core/include/avisynth.h


### PR DESCRIPTION
~~~
CMake Warning (dev) at /usr/share/cmake-3.17/Modules/GNUInstallDirs.cmake:225 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  CMakeLists.txt:31 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
~~~