### PR TITLE
CMakeLists: check correct flag on linking to stdc++fs

### DIFF
--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -88,7 +88,7 @@ target_include_directories("AvsCore" PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_definitions("AvsCore" PRIVATE BUILDING_AVSCORE)
 
 # stdc++fs was mainlined into stdc++ in GCC 9, but GCC 8 can build it too
-if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
     set(FSLIB "stdc++fs")
 endif()
 


### PR DESCRIPTION
It triggered warnings on GCC 8.3 on Debian buster, where CMAKE_COMPILER_IS_GNUCC is not defined due to, probably, no C compiler is checked for explicitly claimed CXX projects, as a result of 8d179bf9c1326839adc9d243a74037308985b968.