### PR TITLE
Add a GitHub action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build AviSynth+
+
+on: [push]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+        - {name: "Windows Latest x64", os: windows-latest, cmake-parameters: "-A x64"}
+        - {name: "Windows Latest x86", os: windows-latest, cmake-parameters: "-A Win32"}
+        - {name: "Ubuntu 18.04 x64 (fs compat)", os: ubuntu-18.04, checkout-submodules: true}
+        - {name: "Ubuntu 20.04 x64", os: ubuntu-20.04}
+        - {name: "macOS Latest x64", os: macos-latest}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: ${{ matrix.config.checkout-submodules }}
+
+    - name: configure
+      run: |
+        cmake -S . -B avisynth-build ${{ matrix.config.cmake-parameters }}
+
+    - name: build
+      run: |
+        cmake --build avisynth-build --config Release -j 2


### PR DESCRIPTION
This adds a GitHub action workflow file which on every commit
triggers an MSVC release build for x86/x64. The binaries and
readme files are then stored as a GitHub action artifact.

These packages can be used for manual testing by AviSynth
users.

The workflow could also be extended to build complete
installers via InnoSetup.