### PR TITLE
posix: fix crash when autoloading imports

### DIFF
--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -707,7 +707,7 @@ void PluginManager::AutoloadPlugins()
         for (size_t i = 0; i < AutoLoadedImports.size(); ++i)
         {
 #ifdef AVS_POSIX
-          if (AutoLoadedPlugins[i].BaseName == p.BaseName) // case insensitive
+          if (AutoLoadedImports[i].BaseName == p.BaseName) // case insensitive
 #else
           if (streqi(AutoLoadedImports[i].BaseName.c_str(), p.BaseName.c_str()))
 #endif


### PR DESCRIPTION
Caused by a typo in an array name.
By the way, is that comparison actually case insensitive? The comment doesn't tell why.