### PR TITLE
ConvertAudio: add missing AVX2 calls

### DIFF
--- a/avs_core/convert/convert_audio.cpp
+++ b/avs_core/convert/convert_audio.cpp
@@ -163,6 +163,7 @@ void __stdcall ConvertAudio::GetAudio(void *buf, int64_t start, int64_t count, I
       if ((cpu_flags & CPUF_AVX2)) {
         if (convert_avx2)
           convert = convert_avx2;
+        convert_float = src_format == SAMPLE_FLOAT ? convertFLTTo32_AVX2 : convert32ToFLT_AVX2;
       }
     #endif
   }


### PR DESCRIPTION
The float-32 and 32-float was forgotten.