### PR TITLE
Support static library build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ file(READ "avs_core/include/avisynth.h" versioning)
 string(REGEX MATCH "AVISYNTH_INTERFACE_VERSION = ([0-9]*)" _ ${versioning})
 set(AVISYNTH_INTERFACE_VERSION ${CMAKE_MATCH_1})
 
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones." ON)
+if(NOT ${BUILD_SHARED_LIBS})
+  message(WARNING "You must satisfy the conditions of the GPL license when linking against the AviSynth library.")
+endif()
+
 option(HEADERS_ONLY "Install only the Headers" ${INSTALL_ONLY_HEADER})
 if(${INSTALL_ONLY_HEADER})
   set(INSTALL_ONLY_HEADER OFF)

--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 # Create library
 project("AvsCore" VERSION "${PROJECT_VERSION}" LANGUAGES CXX)
 Include("Files.cmake")
-add_library("AvsCore" SHARED ${AvsCore_Sources})
+add_library("AvsCore" ${AvsCore_Sources})
 set_target_properties("AvsCore" PROPERTIES "OUTPUT_NAME" "${CoreName}")
 if (NOT WIN32)
   set_target_properties("AvsCore" PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION "${AVISYNTH_INTERFACE_VERSION}")


### PR DESCRIPTION
Allows users to build the library statically, by passing ``-DBUILD_SHARED_LIBS=OFF`` on the command line.