### PR TITLE
[WIP] Haiku support

### DIFF
--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -102,10 +102,16 @@ if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
     set(FSLIB "stdc++fs")
 endif()
 
-# Windows DLL dependencies
+# Per-OS link dependencies
 if (MSVC OR MINGW)
   target_link_libraries("AvsCore" "uuid" "winmm" "vfw32" "msacm32" "gdi32" "user32" "advapi32" "ole32" "imagehlp")
-else()
+endif()
+
+if (HAIKU)
+  target_link_libraries("AvsCore" "pthread" "${FSLIB}")
+endif()
+
+if (LINUX OR APPLE OR BSD)
   target_link_libraries("AvsCore" "pthread" "dl" "${FSLIB}")
 endif()
 

--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -108,7 +108,7 @@ if (MSVC OR MINGW)
 endif()
 
 if (HAIKU)
-  target_link_libraries("AvsCore" "pthread" "${FSLIB}")
+  target_link_libraries("AvsCore" "root" "${FSLIB}")
 endif()
 
 if (LINUX OR APPLE OR BSD)

--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -575,7 +575,13 @@ void PluginManager::AddAutoloadDir(const std::string &dirPath, bool toFront)
 #endif
   std::string ExeFileDir(ExeFilePath);
   replace(ExeFileDir, '\\', '/');
+#ifndef AVS_HAIKU
+// Haiku's exe path stuff differs enough from the *nix OSes
+// that it fails spectacularly when loading the library in a client
+// like avs2yuv or FFmpeg.  Try to skip this for now and hope
+// this doesn't cause more errors.
   ExeFileDir = ExeFileDir.erase(ExeFileDir.rfind('/'), std::string::npos);
+#endif
 
   // variable expansion
   replace_beginning(dir, "SCRIPTDIR", Env->GetVarString("$ScriptDir$", ""));

--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -64,7 +64,11 @@
 #else
     #include <avs/filesystem.h>
     #include <set>
+#if defined(AVS_HAIKU)
+    #include <kernel/OS.h>
+#else
     #include <sys/sysinfo.h>
+#endif
 #endif
     #include <avs/posix.h>
 #endif
@@ -2059,6 +2063,10 @@ static uint64_t posix_get_physical_memory() {
   int64_t memsize;
   sysctlbyname("hw.physmem", (void*)&memsize, &len, nullptr, 0);
   ullTotalPhys = memsize;
+#elif defined(AVS_HAIKU)
+  // to-do on detecting this dynamically, but for right now limit to 1GB since we're
+  // testing in a VM
+  ullTotalPhys = 1024 * 1024 * 1024;
 #else
   // linux
   struct sysinfo info;
@@ -2084,6 +2092,8 @@ static int64_t posix_get_available_memory() {
 #elif defined(AVS_BSD)
   size_t nAvailablePhysicalPagesLen = sizeof(nAvailablePhysicalPages);
   sysctlbyname("vm.stats.vm.v_free_count", &nAvailablePhysicalPages, &nAvailablePhysicalPagesLen, NULL, 0);
+#elif defined(AVS_HAIKU)
+  // to-do
 #else // Linux
   nAvailablePhysicalPages = sysconf(_SC_AVPHYS_PAGES);
 #endif

--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -2064,9 +2064,9 @@ static uint64_t posix_get_physical_memory() {
   sysctlbyname("hw.physmem", (void*)&memsize, &len, nullptr, 0);
   ullTotalPhys = memsize;
 #elif defined(AVS_HAIKU)
-  // to-do on detecting this dynamically, but for right now limit to 1GB since we're
-  // testing in a VM
-  ullTotalPhys = 1024 * 1024 * 1024;
+  system_info sysinf;
+  get_system_info(&sysinf);
+  ullTotalPhys = 4096 * sysinf.max_pages;
 #else
   // linux
   struct sysinfo info;
@@ -2093,7 +2093,9 @@ static int64_t posix_get_available_memory() {
   size_t nAvailablePhysicalPagesLen = sizeof(nAvailablePhysicalPages);
   sysctlbyname("vm.stats.vm.v_free_count", &nAvailablePhysicalPages, &nAvailablePhysicalPagesLen, NULL, 0);
 #elif defined(AVS_HAIKU)
-  // to-do
+  system_info sysinf;
+  get_system_info(&sysinf);
+  nAvailablePhysicalPages = sysinf.free_memory;
 #else // Linux
   nAvailablePhysicalPages = sysconf(_SC_AVPHYS_PAGES);
 #endif

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -71,6 +71,10 @@
 #endif
 
 #if defined(AVS_POSIX)
+#if defined(AVS_HAIKU)
+#undef __stdcall
+#undef __cdecl
+#endif
 #define __stdcall
 #define __cdecl
 #endif

--- a/avs_core/include/avs/capi.h
+++ b/avs_core/include/avs/capi.h
@@ -37,7 +37,9 @@
 
 #ifdef AVS_POSIX
 // this is also defined in avs/posix.h
+#ifndef AVS_HAIKU
 #define __declspec(x)
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/avs_core/include/avs/config.h
+++ b/avs_core/include/avs/config.h
@@ -98,6 +98,9 @@
 #elif defined(__APPLE__)
 #   define AVS_MACOS
 #   define AVS_POSIX
+#elif defined(__HAIKU__)
+#   define AVS_HAIKU
+#   define AVS_POSIX
 #else
 #   error Operating system unsupported.
 #endif

--- a/avs_core/include/avs/posix.h
+++ b/avs_core/include/avs/posix.h
@@ -43,6 +43,9 @@
 #define __single_inheritance
 
 // These things don't exist in Linux
+#if defined(AVS_HAIKU)
+#undef __declspec
+#endif
 #define __declspec(x)
 #define lstrlen strlen
 #define lstrcmp strcmp
@@ -104,8 +107,10 @@
 #define STATUS_STACK_OVERFLOW 0xc00000fd
 
 // Calling convension
+#ifndef AVS_HAIKU
 #define __stdcall
 #define __cdecl
+#endif
 
 #endif // AVSCORE_POSIX_H
 #endif // AVS_POSIX


### PR DESCRIPTION
What works: compiling the library into libavisynth.so
What doesn't: actually using it in either avs2yuv or FFmpeg

Haiku is a re-implementation of BeOS, and something like this was brought up in a (long-since-closed) issue on Haiku's bug tracker, way back when expecting the Ruby-based 3.0 was still a thing:
https://dev.haiku-os.org/ticket/3907


I've recently been tinkering on getting AviSynth+ running on Haiku, but I've hit a bit of a roadblock.  The library compiles, but when I attempt to load it in other applications (avs2yuv, or an FFmpeg that's been rebuilt with *--enable-avisynth*), I'm getting errors related to string handling.  But the backtraces from gdb don't seem to point at a particular area and the message given by the system about the error doesn't really match the parts of the code that use std::string.

The relevant bits of error and debug messages are below:
```
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::erase: __pos (which is 18446744073709551615) > this->size() (which is 1)
Abort
Kill Thread
```

gdb output from avs2yuv
```
Program received signal SIGTRAP, Trace/breakpoint trap.
0x0000014232aef1c1 in _kern_debugger () from /boot/system/lib/libroot.so
(gdb) bt
#0  0x0000014232aef1c1 in _kern_debugger () from /boot/system/lib/libroot.so
#1  0x0000014232ae6c98 in abort () from /boot/system/lib/libroot.so
#2  0x0000014232ae7077 in __gnu_cxx::__verbose_terminate_handler ()
   from /boot/system/lib/libroot.so
#3  0x0000014232b7d369 in __cxxabiv1::__terminate ()
   from /boot/system/lib/libroot.so
#4  0x0000014232b7d3b1 in std::terminate () from /boot/system/lib/libroot.so
#5  0x0000014232b7d50c in __cxa_throw () from /boot/system/lib/libroot.so
#6  0x000001b95e921cab in std::__throw_out_of_range_fmt ()
   from /boot/system/lib/libstdc++.so.6.0.25
#7  0x000001f8026536d6 in std::string::_M_check ()
   from /boot/home/avsplus_build/lib/libavisynth.so.3.6.2
#8  0x000001f80266393f in std::string::erase ()
   from /boot/home/avsplus_build/lib/libavisynth.so.3.6.2
#9  0x000001f80265fdf5 in PluginManager::AddAutoloadDir ()
   from /boot/home/avsplus_build/lib/libavisynth.so.3.6.2
#10 0x000001f80267bd93 in ScriptEnvironment::ScriptEnvironment ()
   from /boot/home/avsplus_build/lib/libavisynth.so.3.6.2
#11 0x000001f802686eec in CreateScriptEnvironment2 ()
   from /boot/home/avsplus_build/lib/libavisynth.so.3.6.2
#12 0x000001f802686e8c in CreateScriptEnvironment ()
   from /boot/home/avsplus_build/lib/libavisynth.so.3.6.2
#13 0x000001f8026b12b2 in avs_create_script_environment ()
   from /boot/home/avsplus_build/lib/libavisynth.so.3.6.2
---Type <return> to continue, or q <return> to quit---
#14 0x00000043ffa870a8 in main ()
(gdb) 
```