### PR TITLE
Make static linking work in Windows

### DIFF
--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -87,6 +87,10 @@ target_include_directories("AvsCore" PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 # Specify preprocessor definitions
 target_compile_definitions("AvsCore" PRIVATE BUILDING_AVSCORE)
 
+if(NOT ${BUILD_SHARED_LIBS})
+    target_compile_definitions("AvsCore" PRIVATE AVS_STATIC_LIB)
+endif()
+
 # If checked out with compat filesystem submodule, add that to system include directories
 get_filename_component(
     GHS_FILESYSTEM_INCLUDE_DIR

--- a/avs_core/core/main.cpp
+++ b/avs_core/core/main.cpp
@@ -274,7 +274,7 @@ private:
   HRESULT Read2(LONG lStart, LONG lSamples, LPVOID lpBuffer, LONG cbBuffer, LONG *plBytes, LONG *plSamples);
 };
 
-void AvsAllocTls() {
+AVSC_API(void, AvsAllocTls)() {
 
 #ifdef XP_TLS
   if ((dwTlsIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)
@@ -283,7 +283,7 @@ void AvsAllocTls() {
 #endif
 }
 
-void AvsFreeTls() {
+AVSC_API(void, AvsFreeTls)() {
 
 #ifdef XP_TLS
     _RPT1(0, "DllMain: TlsFree: dwTlsIndex=0x%x\n", dwTlsIndex);

--- a/avs_core/core/main.cpp
+++ b/avs_core/core/main.cpp
@@ -274,7 +274,11 @@ private:
   HRESULT Read2(LONG lStart, LONG lSamples, LPVOID lpBuffer, LONG cbBuffer, LONG *plBytes, LONG *plSamples);
 };
 
+#ifdef AVS_STATIC_LIB
 AVSC_API(void, AvsAllocTls)() {
+#else
+void AvsAllocTls() {
+#endif
 
 #ifdef XP_TLS
   if ((dwTlsIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)
@@ -283,7 +287,11 @@ AVSC_API(void, AvsAllocTls)() {
 #endif
 }
 
+#ifdef AVS_STATIC_LIB
 AVSC_API(void, AvsFreeTls)() {
+#else
+void AvsFreeTls() {
+#endif
 
 #ifdef XP_TLS
     _RPT1(0, "DllMain: TlsFree: dwTlsIndex=0x%x\n", dwTlsIndex);

--- a/avs_core/core/main.cpp
+++ b/avs_core/core/main.cpp
@@ -274,43 +274,24 @@ private:
   HRESULT Read2(LONG lStart, LONG lSamples, LPVOID lpBuffer, LONG cbBuffer, LONG *plBytes, LONG *plSamples);
 };
 
-#ifdef AVS_STATIC_LIB
-AVSC_API(void, AvsAllocTls)() {
-#else
-void AvsAllocTls() {
-#endif
-
-#ifdef XP_TLS
-  if ((dwTlsIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)
-    throw("Avisynth DLL load: TlsAlloc failed");
-  _RPT1(0, "DllMain: TlsAlloc: dwTlsIndex=0x%x\n", dwTlsIndex);
-#endif
-}
-
-#ifdef AVS_STATIC_LIB
-AVSC_API(void, AvsFreeTls)() {
-#else
-void AvsFreeTls() {
-#endif
-
-#ifdef XP_TLS
-    _RPT1(0, "DllMain: TlsFree: dwTlsIndex=0x%x\n", dwTlsIndex);
-    TlsFree(dwTlsIndex);
-    dwTlsIndex = 0;
-#endif
-}
-
 #ifndef AVS_STATIC_LIB
 BOOL APIENTRY DllMain(HANDLE hModule, ULONG ulReason, LPVOID lpReserved) {
 
   _RPT4(0,"DllMain: hModule=0x%08x, ulReason=%x, lpReserved=0x%08x, gRefCnt = %ld\n",
     hModule, ulReason, lpReserved, gRefCnt);
 
+#ifdef XP_TLS
   if (ulReason == DLL_PROCESS_ATTACH) {
-    AvsAllocTls();
-  } else if (ulReason == DLL_PROCESS_DETACH) {
-    AvsFreeTls();
+    if ((dwTlsIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)
+      throw("Avisynth DLL load: TlsAlloc failed");
+    _RPT1(0, "DllMain: TlsAlloc: dwTlsIndex=0x%x\n", dwTlsIndex);
   }
+  else if (ulReason == DLL_PROCESS_DETACH) {
+    _RPT1(0, "DllMain: TlsFree: dwTlsIndex=0x%x\n", dwTlsIndex);
+    TlsFree(dwTlsIndex);
+    dwTlsIndex = 0;
+  }
+#endif
 
   return TRUE;
 }

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -1902,11 +1902,6 @@ AVSC_API(IScriptEnvironment*, CreateScriptEnvironment)(int version = AVISYNTH_IN
 #include "avs/capi.h"
 AVSC_API(IScriptEnvironment2*, CreateScriptEnvironment2)(int version = AVISYNTH_INTERFACE_VERSION);
 
-#ifdef AVS_STATIC_LIB
-AVSC_API(void, AvsAllocTls)();
-AVSC_API(void, AvsFreeTls)();
-#endif
-
 #ifndef BUILDING_AVSCORE
 #undef AVS_UNUSED
 #endif

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -420,7 +420,7 @@ struct AVS_Linkage {
   // this part should be identical with AVS_Linkage entries in interface.cpp
 };
 
-#ifdef BUILDING_AVSCORE
+#if defined(BUILDING_AVSCORE) || defined(AVS_STATIC_LIB)
 /* Macro resolution for code inside Avisynth.dll */
 # define AVS_BakedCode(arg) ;
 # define AVS_LinkCall(arg)
@@ -1862,7 +1862,7 @@ struct PNeoEnv {
   INeoEnv* p;
   PNeoEnv() : p() { }
   PNeoEnv(IScriptEnvironment* env)
-#ifdef BUILDING_AVSCORE
+#if defined(BUILDING_AVSCORE) || defined(AVS_STATIC_LIB)
     ;
 #else
   : p(!AVS_linkage || offsetof(AVS_Linkage, GetNeoEnv) >= AVS_linkage->Size ? 0 : AVS_linkage->GetNeoEnv(env)) { }
@@ -1901,6 +1901,11 @@ AVSC_API(IScriptEnvironment*, CreateScriptEnvironment)(int version = AVISYNTH_IN
 // C exports
 #include "avs/capi.h"
 AVSC_API(IScriptEnvironment2*, CreateScriptEnvironment2)(int version = AVISYNTH_INTERFACE_VERSION);
+
+#ifdef AVS_STATIC_LIB
+AVSC_API(void, AvsAllocTls)();
+AVSC_API(void, AvsFreeTls)();
+#endif
 
 #ifndef BUILDING_AVSCORE
 #undef AVS_UNUSED

--- a/avs_core/include/avs/capi.h
+++ b/avs_core/include/avs/capi.h
@@ -105,6 +105,7 @@
 #  define AVSC_API(ret, name) EXTERN_C ret AVSC_CC name
 #endif
 #else
+#  define AVSC_EXPORT EXTERN_C __declspec(dllexport)
 #  ifndef AVS_STATIC_LIB
 #    define AVSC_IMPORT __declspec(dllimport)
 #  else

--- a/avs_core/include/avs/capi.h
+++ b/avs_core/include/avs/capi.h
@@ -94,16 +94,24 @@
 
 #ifdef BUILDING_AVSCORE
 #ifdef AVS_WINDOWS
-#  define AVSC_EXPORT __declspec(dllexport)
+#  ifndef AVS_STATIC_LIB
+#    define AVSC_EXPORT __declspec(dllexport)
+#  else
+#    define AVSC_EXPORT
+#  endif
 #  define AVSC_API(ret, name) EXTERN_C AVSC_EXPORT ret AVSC_CC name
 #else
 #  define AVSC_EXPORT EXTERN_C
 #  define AVSC_API(ret, name) EXTERN_C ret AVSC_CC name
 #endif
 #else
-#  define AVSC_EXPORT EXTERN_C __declspec(dllexport)
+#  ifndef AVS_STATIC_LIB
+#    define AVSC_IMPORT __declspec(dllimport)
+#  else
+#    define AVSC_IMPORT
+#  endif
 #  ifndef AVSC_NO_DECLSPEC
-#    define AVSC_API(ret, name) EXTERN_C __declspec(dllimport) ret AVSC_CC name
+#    define AVSC_API(ret, name) EXTERN_C AVSC_IMPORT ret AVSC_CC name
 #  else
 #    define AVSC_API(ret, name) typedef ret (AVSC_CC *name##_func)
 #  endif


### PR DESCRIPTION
To use the generated .lib file, I made the following changes to my own program:

1. Put `#define AVS_STATIC_LIB` before `#include <avisynth.h>`.
2. Obviously, remove all the `AVS_linkage` stuff.
3. Replace `LoadLibrary()` with `AvsAllocTls()`.
4. Replace `FreeLibrary()` with `AvsFreeTls()`.
5. Add the new dependencies. Can be done in MSVC project config too:
```
#pragma comment(lib, "AviSynth.lib")
#pragma comment(lib, "imagehlp.lib")
#pragma comment(lib, "msacm32.lib")
#pragma comment(lib, "vfw32.lib")
```

I don't know what `CAVIFileSynth` is, and I don't use it, so I didn't change anything about `DllGetClassObject` and `DllCanUnloadNow`.