### PR TITLE
cmake: fix Libs.private in generated .pc file

### DIFF
--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -111,12 +111,14 @@ else()
     set(SYSLIB "m" "pthread" "dl")
 endif()
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     list(APPEND SYSLIB "stdc++")
     # stdc++fs was mainlined into stdc++ in GCC 9, but GCC 8 can build it too
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
         list(APPEND SYSLIB "stdc++fs")
     endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    list(APPEND SYSLIB "c++")
 endif()
 
 target_link_libraries("AvsCore" ${SYSLIB})

--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -106,12 +106,15 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Haiku")
 elseif(MSVC OR MINGW)
     set(SYSLIB "uuid" "winmm" "vfw32" "msacm32" "gdi32" "user32" "advapi32" "ole32" "imagehlp")
 else()
-    set(SYSLIB "pthread" "dl" "stdc++" "m")
+    set(SYSLIB "pthread" "dl" "m")
 endif()
 
-# stdc++fs was mainlined into stdc++ in GCC 9, but GCC 8 can build it too
-if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-    list(APPEND SYSLIB "stdc++fs")
+if (CMAKE_COMPILER_IS_GNUCXX)
+    list(APPEND SYSLIB "stdc++")
+    # stdc++fs was mainlined into stdc++ in GCC 9, but GCC 8 can build it too
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+        list(APPEND SYSLIB "stdc++fs")
+    endif()
 endif()
 
 target_link_libraries("AvsCore" ${SYSLIB})

--- a/avs_core/CMakeLists.txt
+++ b/avs_core/CMakeLists.txt
@@ -101,26 +101,20 @@ if (EXISTS ${GHS_FILESYSTEM_INCLUDE_DIR})
     target_include_directories("AvsCore" SYSTEM PRIVATE ${GHS_FILESYSTEM_INCLUDE_DIR})
 endif()
 
-# stdc++fs was mainlined into stdc++ in GCC 9, but GCC 8 can build it too
-if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-    set(FSLIB "stdc++fs")
-endif()
-
 if (CMAKE_SYSTEM_NAME STREQUAL "Haiku")
     set(SYSLIB "root")
-    set(SYSLIBS "-lroot")
+elseif(MSVC OR MINGW)
+    set(SYSLIB "uuid" "winmm" "vfw32" "msacm32" "gdi32" "user32" "advapi32" "ole32" "imagehlp")
 else()
-    set(SYSLIB "pthread" "dl")
-    set(SYSLIBS "-lpthread -ldl")
+    set(SYSLIB "pthread" "dl" "stdc++" "m")
 endif()
 
-# Per-OS link dependencies
-if (MSVC OR MINGW)
-  target_link_libraries("AvsCore" "uuid" "winmm" "vfw32" "msacm32" "gdi32" "user32" "advapi32" "ole32" "imagehlp")
-else()
-  target_link_libraries("AvsCore" "${SYSLIB}" "${FSLIB}")
+# stdc++fs was mainlined into stdc++ in GCC 9, but GCC 8 can build it too
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+    list(APPEND SYSLIB "stdc++fs")
 endif()
 
+target_link_libraries("AvsCore" ${SYSLIB})
 
 if(ENABLE_CUDA)
   if(${CMAKE_VERSION} VERSION_LESS "3.19.5")
@@ -131,6 +125,7 @@ if(ENABLE_CUDA)
       #target_link_libraries ("AvsCore" ${CUDA_LIBRARIES})
       target_link_libraries ("AvsCore" ${CUDA_cudart_static_LIBRARY})
       target_compile_definitions("AvsCore" PUBLIC ENABLE_CUDA)
+      list(APPEND SYSLIB "cudart_static")
     endif()
   else()
     # Fixed in 3.19.5: https://gitlab.kitware.com/cmake/cmake/-/issues/21740
@@ -140,6 +135,7 @@ if(ENABLE_CUDA)
       target_include_directories("AvsCore" PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
       target_link_libraries ("AvsCore" CUDA::cudart_static)
       target_compile_definitions("AvsCore" PUBLIC ENABLE_CUDA)
+      list(APPEND SYSLIB "cudart_static")
     endif()
   endif()
 endif()
@@ -192,6 +188,9 @@ endif()
 # Generate pkg-config file
 get_target_property(LIB_NAME AvsCore OUTPUT_NAME)
 set(LIBS "-l${LIB_NAME}")
+set(_SYSLIBS_ITEMS ${SYSLIB})
+list(TRANSFORM _SYSLIBS_ITEMS PREPEND "-l")
+list(JOIN _SYSLIBS_ITEMS " " SYSLIBS)
 CONFIGURE_FILE("avisynth.pc.in" "avisynth.pc" @ONLY)
 
 # Generate avisynth.conf

--- a/avs_core/avisynth.pc.in
+++ b/avs_core/avisynth.pc.in
@@ -8,6 +8,6 @@ Description: A powerful nonlinear scripting language for video.
 Version: @PROJECT_VERSION@
 
 Libs: -L${libdir} @LIBS@
-Libs.private: -L${libdir} @SYSLIBS@
+Libs.private: @SYSLIBS@
 Cflags: -I${includedir}
 Cflags.private: -DAVS_STATIC_LIB

--- a/avs_core/avisynth.pc.in
+++ b/avs_core/avisynth.pc.in
@@ -10,3 +10,4 @@ Version: @PROJECT_VERSION@
 Libs: -L${libdir} @LIBS@
 Libs.private: -L${libdir} @SYSLIBS@
 Cflags: -I${includedir}
+Cflags.private: -DAVS_STATIC_LIB


### PR DESCRIPTION
When using a statically compiled avisynth on linux using the C API with pkg-config, linking fails due to missing -lstdc++ and -lm flags. Additionally, on windows, the .pc file appears to be missing system libraries. This patch fixes both issues. I tested by compiling against a patched ffmpeg to allow static linking of avisynthplus on linux and osx.

Note that I didn't have CUDA to test, and I'm not entirely sure if a .pc file for it is available. If so, it's probably better to list it under Requires.private instead of hardcoding "-lcudart_static". Some assistance with that would be appreciated.

I also realize that the Cflags in the .pc file may need ``-DAVS_STATIC_LIB`` for static builds, to reflect #205. Linux/osx are happy without it but it may be necessary for windows. I may look at that in a follow-up.

cc @qyot27 (given previous conversations about static linking)