### PR TITLE
pkg-config: use prefix for includedir instead of exec_prefix

### DIFF
--- a/avs_core/avisynth.pc.in
+++ b/avs_core/avisynth.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@/avisynth
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/avisynth
 
 Name: AviSynth+
 Description: A powerful nonlinear scripting language for video.


### PR DESCRIPTION
``${exec_prefix}`` is only meant to be used for libraries and not for non-machine specific files such as headers; see https://www.gnu.org/prep/standards/html_node/Directory-Variables.html and also the example in the pkg-config docs: https://people.freedesktop.org/~dbn/pkg-config-guide.html#using

Some systems may override the prefixes when relocating the libraries. For instance, vcpkg relocates the libraries (but not the headers) and adjusts the .pc file accordingly to allow simultaneous installation of release and debug builds. (This patch thus fixes a vcpkg compile error when using pkg-config to link against avs+.)