### PR TITLE
Fix build failure due to missing size_t

### DIFF
--- a/avs_core/core/BufferPool.h
+++ b/avs_core/core/BufferPool.h
@@ -10,12 +10,12 @@ class BufferPool
 private:
 
   struct BufferDesc;
-  typedef std::multimap<size_t, BufferDesc*> MapType;
+  typedef std::multimap<std::size_t, BufferDesc*> MapType;
 
   InternalEnvironment* Env;
   MapType Map;
 
-  void* PrivateAlloc(size_t nBytes, size_t alignment, void* user);
+  void* PrivateAlloc(std::size_t nBytes, std::size_t alignment, void* user);
   void PrivateFree(void* buffer);
 
 public:
@@ -23,7 +23,7 @@ public:
   BufferPool(InternalEnvironment* env);
   ~BufferPool();
 
-  void* Allocate(size_t nBytes, size_t alignment, bool pool);
+  void* Allocate(std::size_t nBytes, std::size_t alignment, bool pool);
   void Free(void* ptr);
 
 };


### PR DESCRIPTION
There are a lot of build failures like the following:

```
In file included from /build/avisynthplus/src/AviSynthPlus-3.7.0/avs_core/core/BufferPool.cpp:1:
/build/avisynthplus/src/AviSynthPlus-3.7.0/avs_core/core/BufferPool.h:13:25: error: ‘size_t’ was not declared in this scope; did you mean ‘std::size_t’?
   13 |   typedef std::multimap<size_t, BufferDesc*> MapType;
      |                         ^~~~~~
      |                         std::size_t
In file included from /usr/include/c++/11.1.0/bits/stl_algobase.h:59,
                 from /usr/include/c++/11.1.0/bits/stl_tree.h:63,
                 from /usr/include/c++/11.1.0/map:60,
                 from /build/avisynthplus/src/AviSynthPlus-3.7.0/avs_core/core/BufferPool.h:4,
                 from /build/avisynthplus/src/AviSynthPlus-3.7.0/avs_core/core/BufferPool.cpp:1:
/usr/include/c++/11.1.0/x86_64-pc-linux-gnu/bits/c++config.h:280:33: note: ‘std::size_t’ declared here
  280 |   typedef __SIZE_TYPE__         size_t;
      |                                 ^~~~~~
...
```

This change fixes them and the build went on until the end.