### PR TITLE
Fix build failure on Linux when optimizations are enabled

### DIFF
--- a/avs_core/filters/turn.cpp
+++ b/avs_core/filters/turn.cpp
@@ -85,6 +85,10 @@ void turn_right_plane_c(const BYTE* srcp, BYTE* dstp, int src_rowsize, int heigh
 }
 
 
+// Explicit instantiation, can be used from other modules.
+template void turn_right_plane_c<uint64_t>(const BYTE*, BYTE*, int, int, int, int);
+
+
 void turn_right_plane_8_c(const BYTE* srcp, BYTE* dstp, int src_rowsize, int src_height, int src_pitch, int dst_pitch)
 {
     turn_right_plane_c<BYTE>(srcp, dstp, src_rowsize, src_height, src_pitch, dst_pitch);


### PR DESCRIPTION
```
/usr/bin/ld: CMakeFiles/AvsCore.dir/filters/intel/turn_sse.cpp.o: in function `turn_left_rgb64_sse2(unsigned char const*, unsigned char*, int, int, int, int)':
turn_sse.cpp:(.text+0xa34): undefined reference to `void turn_right_plane_c<unsigned long>(unsigned char const*, unsigned char*, int, int, int, int)'
/usr/bin/ld: CMakeFiles/AvsCore.dir/filters/intel/turn_sse.cpp.o: in function `turn_right_rgb64_sse2(unsigned char const*, unsigned char*, int, int, int, int)':
turn_sse.cpp:(.text+0xbd3): undefined reference to `void turn_right_plane_c<unsigned long>(unsigned char const*, unsigned char*, int, int, int, int)'
/usr/bin/ld: CMakeFiles/AvsCore.dir/filters/intel/turn_sse.cpp.o: in function `turn_left_rgb64_sse2(unsigned char const*, unsigned char*, int, int, int, int)':
turn_sse.cpp:(.text+0xa7f): undefined reference to `void turn_right_plane_c<unsigned long>(unsigned char const*, unsigned char*, int, int, int, int)'
/usr/bin/ld: CMakeFiles/AvsCore.dir/filters/intel/turn_sse.cpp.o: in function `turn_right_rgb64_sse2(unsigned char const*, unsigned char*, int, int, int, int)':
turn_sse.cpp:(.text+0xc1f): undefined reference to `void turn_right_plane_c<unsigned long>(unsigned char const*, unsigned char*, int, int, int, int)'
```

The `turn_right_plane_c` template is used from `turn_sse.cpp` even though it is defined in `turn.cpp`. When optimizations are enabled, `turn_right_plane_c` gets inlined and the linker cannot find it.

If these templates are meant to be reused, they should just be defined in the header.