### PR TITLE
[RFC] Add ArrayMap, ArrayFlapMap and ArrayReduce operations

### DIFF
--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -279,6 +279,9 @@ bool AVSFunction::IsScriptFunction(const Function* func)
           || (func->apply == &Eval)
           || (func->apply == &EvalOop)
           || (func->apply == &Import)
+          || (func->apply == &ArrayMap)
+          || (func->apply == &ArrayFlatMap)
+          || (func->apply == &ArrayReduce)
         );
 }
 

--- a/avs_core/core/parser/script.h
+++ b/avs_core/core/parser/script.h
@@ -293,5 +293,8 @@ AVSValue ArrayGet(AVSValue args, void*, IScriptEnvironment* env);
 AVSValue ArraySize(AVSValue args, void*, IScriptEnvironment* env);
 AVSValue ArrayIns(AVSValue args, void*, IScriptEnvironment* env);
 AVSValue ArrayDel(AVSValue args, void*, IScriptEnvironment* env);
+AVSValue ArrayMap(AVSValue args, void*, IScriptEnvironment* env);
+AVSValue ArrayFlatMap(AVSValue args, void*, IScriptEnvironment* env);
+AVSValue ArrayReduce(AVSValue args, void*, IScriptEnvironment* env);
 
 #endif  // __Script_H__

--- a/distrib/docs/english/source/avisynthdoc/script_ref/script_ref_arrays.rst
+++ b/distrib/docs/english/source/avisynthdoc/script_ref/script_ref_arrays.rst
@@ -20,6 +20,8 @@ Beginning Avisynth+ 3.6 script arrays are supported. Functionality is different 
   - ArrayDel - delete from position
   - ArrayIns - insert before position
   - ArraySet - replace at position
+  - ArrayMap, ArrayFlatMap - create new array with the results of calling a function on every element
+  - ArrayReduce - call a function on every array element with an accumulator value
 
 ArrayIns
 ^^^^^^^^
@@ -56,6 +58,38 @@ ArraySet(array_to_mod, replacement_value, index1 [, index2, index3...])
 
     Returns a new array with array_to_mod[index1 (, index2, index3...)] = replacement_value
     Original array (as with the other functions) remains untouched.
+
+ArrayMap
+^^^^^^^^
+
+ArrayMap(array, callback_fn)
+
+    Creates a new array populated with the results of calling the provided function
+    ``callback_fn`` on every element in ``array``.
+
+ArrayFlatMap
+^^^^^^^^^^^^
+
+ArrayFlatMap(array, callback_fn)
+
+    Creates a new array formed by applying the given function ``callback_fn``,
+    which must return an array, to each element of ``array``, and then
+    concatenating the results.
+
+ArrayReduce
+^^^^^^^^^^^
+
+ArrayReduce(array[, initial_value], callback_fn)
+
+    Executes the supplied function ``callback_fn`` on each element of ``array``,
+    in order, passing in the return value from the calculation on the preceding element
+    as the first argument, and the current array element as the second argument.
+    The final result is a single value.
+
+    The first time that the callback is run there is no "return value of the
+    previous calculation". So ``initial_value``, if supplied, is used in its place.
+    Otherwise, array element 0 is used as the initial value and iteration starts
+    from the next element. In this case, an error is thrown if ``array`` is empty.
 
 ArraySize
 ^^^^^^^^^
@@ -169,6 +203,32 @@ Example:
         }
         return a
       }
+
+Example:
+
+::
+
+      BlankClip(pixel_type="YV12")
+      [1, 2, 3, 4, 5, 6, 7, 8, 9]
+      \   .ArrayMap(function(int i) { [String(i), i] }) # [["1", 1], ["2", 2], ...]
+      \   .ArrayReduce(last, function(clip c, val v) { c.Subtitle(v[0], align=v[1]) })
+
+Example:
+
+::
+
+      text = [["a", [10, 20, 30]], ["b", [40, 50, 60]]]
+      \   .ArrayFlatMap(function(val v) {
+              v[1].ArrayMap(function[v](int i) {
+                  v[0]+String(i)
+              })
+          }) # ["a10", "a20", "a30", "b40", "b50", "b60"]
+      \   .ArrayReduce(function(string acc, string s) {
+              acc+", "+s
+          }) # "a10, a20, a30, b40, b50, b60"
+
+      BlankClip(pixel_type="YV12")
+      Subtitle(text)
 
 Arrays in user defined functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`ArrayMap`, `ArrayFlatMap` and `ArrayReduce` are elemental higher-order array operators. I got inspiration from the similarly-named functions in JavaScript:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce

### Tested behaviour

* This script:
  ```py
  BlankClip(pixel_type="YV12")
  [1, 2, 3, 4, 5, 6, 7, 8, 9]
  \   .ArrayMap(function(int i) { [String(i), i] })
  \   .ArrayReduce(last, function(clip c, val v) { c.Subtitle(v[0], align=v[1]) })
  ```
  Produces the following output:
  ![mpv-shot0001](https://user-images.githubusercontent.com/20713561/147168783-c59cb03a-91d2-40bb-bcc4-6e3cab91225a.jpg)
* This other script:
  ```py
  text = [["a", [10, 20, 30]], ["b", [40, 50, 60]]]
  \   .ArrayFlatMap(function(val v) {
          v[1].ArrayMap(function[v](int i) {
              v[0]+String(i)
          })
      })
  \   .ArrayReduce(function(string acc, string s) {
          acc+", "+s
      })

  BlankClip(pixel_type="YV12")
  Subtitle(text)
  ```
  Produces the following output:
  ![mpv-shot0001](https://user-images.githubusercontent.com/20713561/148314937-d5762e91-c1a4-4c21-9836-d6e9b0d884b8.jpg)
* Empty arrays are handled properly:
  ```py
  Assert([].ArrayMap(function() {}).ArraySize == 0)
  Assert([].ArrayFlatMap(function() {}).ArraySize == 0)
  Assert([].ArrayReduce($AAAA, function() {}) == $AAAA)
  [].ArrayReduce(function() {}) # ArrayReduce: cannot reduce empty array with no initial value.
  ```
* Basic error cases are handled properly:
  ```py
  "a".ArrayMap(function() {}) # ArrayMap: first parameter must be an array.
  [].ArrayMap(1) # Script error: Invalid arguments to function 'ArrayMap'.
  [1].ArrayMap(function() {}) # ArrayMap: cannot process array element 0: invalid arguments to callback function.
  [1, ""].ArrayReduce(1, function(int acc, int elem) { acc }) # ArrayReduce: cannot process array element 1: invalid arguments to callback function.
  [1].ArrayReduce(1, function(int acc, int i) { Assert(false) }) # Assert: assertion failed
  [1].ArrayFlatMap(function(string s) {}) # ArrayFlatMap: cannot process array element 0: invalid arguments to callback function.
  [1].ArrayFlatMap(function(int i) { i }) # ArrayFlatMap: cannot process array element 0: callback function must return an array (got 'int').
  ```
### Issues

<details>
<summary><s>Missing MTGuards</s></summary>

I'm probably doing something wrong, because calling function objects from `ArrayMap` or `ArrayReduce` results in `MTGuard`s being missed.

For example, when I run the following script and set a breakpoint on `SingleFrame::GetFrame`:
```py
f = function(a, b) {
  BlankClip(pixel_type="YV12")
  AutoLevels
  AutoLevels
  AutoLevels
}

f(1, 2)
```

I get the following backtrace:

```c
#0  SingleFrame::GetFrame
#1  Autolevels::getStats
#2  Autolevels::isSceneStart
#3  Autolevels::GetFrame
#4  MTGuard::GetFrame /* OK! */
#5  Cache::GetFrame
#6  CacheGuard::GetFrame
#7  Autolevels::getStats
#8  Autolevels::isSceneStart
#9  Autolevels::GetFrame
#10 MTGuard::GetFrame /* OK! */
#11 Cache::GetFrame
#12 CacheGuard::GetFrame
#13 Autolevels::getStats
#14 Autolevels::isSceneStart
#15 Autolevels::GetFrame
#16 MTGuard::GetFrame /* OK! */
#17 Cache::GetFrame
#18 CacheGuard::GetFrame
#19 Prefetcher::GetFrame
```

But when I run this other script:
```py
f = function(a, b) {
  BlankClip(pixel_type="YV12")
  AutoLevels
  AutoLevels
  AutoLevels
}

[1].ArrayReduce(1, f)
```

The backtrace turns out like this:
```c
#0  SingleFrame::GetFrame
#1  Autolevels::getStats
#2  Autolevels::isSceneStart
#3  Autolevels::GetFrame /* No MTGuard? */
#4  Cache::GetFrame
#5  CacheGuard::GetFrame
#6  Autolevels::getStats
#7  Autolevels::isSceneStart
#8  Autolevels::GetFrame /* No MTGuard? */
#9  Cache::GetFrame
#10 CacheGuard::GetFrame
#11 Autolevels::getStats
#12 Autolevels::isSceneStart
#13 Autolevels::GetFrame /* No MTGuard? */
#14 Cache::GetFrame
#15 CacheGuard::GetFrame /* What? */
#16 MTGuard::GetFrame
#17 Cache::GetFrame
#18 CacheGuard::GetFrame
#19 Prefetcher::GetFrame
```
</details>

Thank you.