### PR TITLE
Fix some uninitialized values

### DIFF
--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -570,7 +570,7 @@ void PluginManager::AddAutoloadDir(const std::string &dirPath, bool toFront)
   GetModuleFileName(NULL, ExeFilePath, AVS_MAX_PATH);
 #else // AVS_POSIX
   std::string ExeFilePath;
-  char buf[PATH_MAX + 1];
+  char buf[PATH_MAX + 1] {};
 #ifdef AVS_LINUX
   if (readlink("/proc/self/exe", buf, sizeof(buf) - 1) != -1)
 #elif defined(AVS_MACOS)

--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -2222,7 +2222,9 @@ ScriptEnvironment::ScriptEnvironment()
   FrontCache(NULL),
   nTotalThreads(1),
   nMaxFilterInstances(1),
-  graphAnalysisEnable(false)
+  graphAnalysisEnable(false),
+  LogLevel(LOGLEVEL_NONE),
+  cacheMode(CACHE_DEFAULT)
 {
 #ifdef XP_TLS
     if(dwTlsIndex == 0)
@@ -2256,8 +2258,6 @@ ScriptEnvironment::ScriptEnvironment()
       plane_align = max(plane_align, align);
     }
 #endif
-
-
 
     auto cpuDevice = Devices->GetCPUDevice();
     threadEnv->GetTLS()->currentDevice = cpuDevice;

--- a/avs_core/core/parser/tokenizer.cpp
+++ b/avs_core/core/parser/tokenizer.cpp
@@ -64,6 +64,7 @@ Tokenizer::Tokenizer(Tokenizer* old)
 {
   pc = old->pc;
   line = old->line;
+  type = old->type;
   NextToken();
 }
 


### PR DESCRIPTION
* 'readlink' does not null-terminate the buffer, so zero-initialize it. We could check the result of 'readlink', but since an ifdef is involved, this solution is simpler.
* 'ScriptEnvironment::LogLevel' and 'ScriptEnvironment::cacheMode'.
* 'Tokenizer::type' when cloning a Tokenizer.