### PR TITLE
Fix: C API avs_prop_get_data

### DIFF
--- a/avs_core/core/avisynth_c.cpp
+++ b/avs_core/core/avisynth_c.cpp
@@ -526,10 +526,10 @@ const char* AVSC_CC avs_prop_get_data(AVS_ScriptEnvironment * p, const AVS_Map *
   p->error = 0;
   try {
     const char* data = p->env->propGetData((const AVSMap*)map, key, index, error);
-    if (error)
+    if (!data)
       return nullptr;
     else
-      return p->env->SaveString(data);
+      return data;
   }
   catch (const AvisynthError& err) {
     p->error = err.msg;

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -95,7 +95,7 @@ enum {
   AVISYNTH_CLASSIC_INTERFACE_VERSION_26BETA = 5,
   AVISYNTH_CLASSIC_INTERFACE_VERSION = 6,
   AVISYNTH_INTERFACE_VERSION = 9,
-  AVISYNTHPLUS_INTERFACE_BUGFIX_VERSION = 0 // reset to zero whenever the normal interface version bumps
+  AVISYNTHPLUS_INTERFACE_BUGFIX_VERSION = 1 // reset to zero whenever the normal interface version bumps
 };
 
 /* Compiler-specific crap */

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -89,7 +89,7 @@
 enum {
   AVISYNTH_INTERFACE_CLASSIC_VERSION = 6,
   AVISYNTH_INTERFACE_VERSION = 9,
-  AVISYNTHPLUS_INTERFACE_BUGFIX_VERSION = 0 // reset to zero whenever the normal interface version bumps
+  AVISYNTHPLUS_INTERFACE_BUGFIX_VERSION = 1 // reset to zero whenever the normal interface version bumps
 };
 #endif
 


### PR DESCRIPTION
Fix the error check.
Return result consistent with the CPP API equivalent function.