### PR TITLE
Remove `PopContextGlobal()` from `Cplusplus_api.rst`

### DIFF
--- a/distrib/docs/english/source/avisynthdoc/FilterSDK/Cplusplus_api.rst
+++ b/distrib/docs/english/source/avisynthdoc/FilterSDK/Cplusplus_api.rst
@@ -846,19 +846,6 @@ PopContext
 ?
 
 
-.. _cplusplus_popcontextglobal:
-
-PopContextGlobal
-^^^^^^^^^^^^^^^^
-
-::
-
-    virtual void __stdcall PopContextGlobal() = 0;
-
-
-?
-
-
 .. _cplusplus_newvideoframe:
 
 NewVideoFrame


### PR DESCRIPTION
In `avisynth.h`, it can only be found in `INeoEnv`, not `IScriptEnvironment`.

Where did it come from? Even IanB talks about it in his post linked for [`PushContext()`](https://avisynthplus.readthedocs.io/en/latest/avisynthdoc/FilterSDK/Cplusplus_api.html#pushcontext).

Was it once part of `IScriptEnvironment`? I thought removing functions invalidates the vtable?
