### PR TITLE
Added `AVSValue::GetType`

### DIFF
--- a/avs_core/core/interface.cpp
+++ b/avs_core/core/interface.cpp
@@ -912,6 +912,8 @@ void AVSValue::Assign2(const AVSValue* src, bool init, bool c_arrays) {
     ((IFunction *)prev_pointer_to_release)->Release();
 }
 
+AvsValueType AVSValue::GetType() const { return (AvsValueType)type; }
+
 // end class AVSValue
 
 /**********************************************************************/
@@ -1178,7 +1180,8 @@ static const AVS_Linkage avs_linkage = {   // struct AVS_Linkage {
 
   &VideoFrameBuffer::DESTRUCTOR,            //   void (VideoFrameBuffer::*VideoFrameBuffer_DESTRUCTOR)();
 
-  NULL,                                     //   reserved for AviSynth+
+  &AVSValue::GetType,                       //   AvsValueType (AVSValue::*AVSValue_GetType)() const;
+
   NULL,                                     //   reserved for AviSynth+
   NULL,                                     //   reserved for AviSynth+
   NULL,                                     //   reserved for AviSynth+

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -184,6 +184,19 @@ enum AvsDeviceType {
   DEV_TYPE_ANY = 0xFFFF
 };
 
+enum AvsValueType {
+  VALUE_TYPE_UNDEFINED = 'v',
+  VALUE_TYPE_BOOL = 'b',
+  VALUE_TYPE_INT = 'i',
+  VALUE_TYPE_LONG = 'l',
+  VALUE_TYPE_FLOAT = 'f',
+  VALUE_TYPE_DOUBLE = 'd',
+  VALUE_TYPE_STRING = 's',
+  VALUE_TYPE_CLIP = 'c',
+  VALUE_TYPE_FUNCTION = 'n',
+  VALUE_TYPE_ARRAY = 'a'
+};
+
 /* Forward references */
 #if defined(MSVC)
     #define SINGLE_INHERITANCE __single_inheritance
@@ -413,13 +426,15 @@ struct AVS_Linkage {
   // end class PDevice
 
   // V9: VideoFrame helper
-  bool              (VideoFrame::* IsPropertyWritable)() const;
+  bool          (VideoFrame::*IsPropertyWritable)() const;
 
-  void (VideoFrameBuffer::*VideoFrameBuffer_DESTRUCTOR)();
+  void          (VideoFrameBuffer::*VideoFrameBuffer_DESTRUCTOR)();
+
+  AvsValueType  (AVSValue::*AVSValue_GetType)() const;
 
   /**********************************************************************/
   // Reserve pointer space for Avisynth+
-  void          (VideoInfo::* reserved2[64 - 25])();
+  void          (VideoInfo::* reserved2[64 - 26])();
   /**********************************************************************/
 
   // AviSynth Neo additions
@@ -1215,7 +1230,7 @@ public:
 //  bool IsLong() const;
   bool IsFloat() const AVS_BakedCode( return AVS_LinkCall(IsFloat)() )
   bool IsString() const AVS_BakedCode( return AVS_LinkCall(IsString)() )
-  bool IsArray() const AVS_BakedCode(return AVS_LinkCall(IsArray)())
+  bool IsArray() const AVS_BakedCode( return AVS_LinkCall(IsArray)() )
   bool IsFunction() const AVS_BakedCode( return AVS_LinkCall(IsFunction)() )
 
   PClip AsClip() const AVS_BakedCode( return AVS_LinkCall(AsClip)() )
@@ -1258,6 +1273,10 @@ private:
   };
 
   void Assign(const AVSValue* src, bool init);
+
+public:
+  AvsValueType GetType() const AVS_BakedCode( return AVS_LinkCallOptDefault(AVSValue_GetType, VALUE_TYPE_UNDEFINED) )
+
 #ifdef BUILDING_AVSCORE
 public:
   void            CONSTRUCTOR0();  /* Damn compiler won't allow taking the address of reserved constructs, make a dummy interlude */

--- a/distrib/Readme/readme_history.txt
+++ b/distrib/Readme/readme_history.txt
@@ -7,9 +7,10 @@ The "rst" version of the documentation just lists changes in brief.
 
 20230202 3.7.3 WIP
 ------------------
-- Gave all enums of public C++ API a name, and added DEFAULT_PLANE to AvsPlane (also in C API).
-- Changed NewVideoFrameP() property source argument to const in accordance with copyFrameProps(), since it's not meant to be written
-- Made VideoFrameBuffer destructor public like in other classes of the public API to prevent compiler errors downstream when calling non-const member functions
+- Feature (#314): Added AVSValue::GetType()
+- Fix (#314): Gave all enums of public C++ API a name, and added DEFAULT_PLANE to AvsPlane (also in C API).
+- Fix (#314): Changed NewVideoFrameP() property source argument to const in accordance with copyFrameProps(), since it's not meant to be written
+- Fix (#314): Made VideoFrameBuffer destructor public like in other classes of the public API to prevent compiler errors downstream when calling non-const member functions
 - "Text": Almost fully rewritten. 
   (#310) Support any width of bdf fonts (but still of fixed width)
   Render in YUY2 is as nice as in YV16


### PR DESCRIPTION
See #314.

In `class AVSValue` in `avisynth.h`, I had to write

```cpp
  AvsValueType GetType() const AVS_BakedCode( return AVS_LinkCallOptDefault(AVSValue_GetType, VALUE_TYPE_UNDEFINED) )
```

instead of

```cpp
  AvsValueType GetType() const AVS_BakedCode( return AVS_LinkCall(AVSValue_GetType) )
```

to get it to work. Same as with `PDevice::GetType()`. I don't know if it's the only way to do it.