### PR TITLE
Added `VideoFrame::GetPixelType()`.

### DIFF
--- a/avs_core/convert/convert.cpp
+++ b/avs_core/convert/convert.cpp
@@ -505,7 +505,6 @@ PVideoFrame __stdcall ConvertToYV12::GetFrame(int n, IScriptEnvironment* env) {
   }
 
   return dst;
-
 }
 
 
@@ -774,7 +773,7 @@ PVideoFrame RemoveAlphaPlane::GetFrame(int n, IScriptEnvironment* env)
   int planes_r[4] = { PLANAR_G, PLANAR_B, PLANAR_R, PLANAR_A };
   int *planes = (vi.IsYUV() || vi.IsYUVA()) ? planes_y : planes_r;
   // Abuse Subframe to snatch the YUV/GBR planes
-  return env->SubframePlanar(src, 0, src->GetPitch(planes[0]), src->GetRowSize(planes[0]), src->GetHeight(planes[0]),0,0,src->GetPitch(planes[1]));
+  return env->SubframePlanar(src, 0, src->GetPitch(planes[0]), src->GetRowSize(planes[0]), src->GetHeight(planes[0]), 0, 0, src->GetPitch(planes[1]));
 
 #if 0
   // BitBlt version. Kept for reference

--- a/avs_core/convert/convert_bits.cpp
+++ b/avs_core/convert/convert_bits.cpp
@@ -1278,6 +1278,8 @@ PVideoFrame __stdcall ConvertBits::GetFrame(int n, IScriptEnvironment* env) {
   if (format_change_only)
   {
     // for 10-16 bit: simple format override in constructor
+    env->MakeWritable(&src);
+    src->AmendPixelType(vi.pixel_type);
     return src;
   }
 

--- a/avs_core/core/interface.cpp
+++ b/avs_core/core/interface.cpp
@@ -973,7 +973,7 @@ PNeoEnv::operator IScriptEnvironment2* () { return static_cast<InternalEnvironme
 
 /**********************************************************************/
 
-static const AVS_Linkage avs_linkage = {   // struct AVS_Linkage {
+static const AVS_Linkage avs_linkage = {    // struct AVS_Linkage {
 
   sizeof(AVS_Linkage),                      //   int Size;
 
@@ -1162,11 +1162,11 @@ static const AVS_Linkage avs_linkage = {   // struct AVS_Linkage {
   &PFunction::DESTRUCTOR,
   // end PFunction
 
-  // Videoframe extras (Neo)
+  // VideoFrame extras (Neo)
   &VideoFrame::CheckMemory,
   &VideoFrame::GetDevice,
 
-    // class PDevice (Neo)
+  // class PDevice (Neo)
   &PDevice::CONSTRUCTOR0,
   &PDevice::CONSTRUCTOR1,
   &PDevice::CONSTRUCTOR2,
@@ -1179,7 +1179,8 @@ static const AVS_Linkage avs_linkage = {   // struct AVS_Linkage {
   &PDevice::GetName,
   // end class PDevice
 
-  &VideoFrame::IsPropertyWritable,          //   V9
+  // V9
+  &VideoFrame::IsPropertyWritable,
 
   // V10
   &VideoFrame::GetPixelType,                //   int          (VideoFrame::*VideoFrame_GetPixelType)() const;

--- a/avs_core/core/interface.cpp
+++ b/avs_core/core/interface.cpp
@@ -527,6 +527,9 @@ int VideoFrame::GetHeight(int plane) const {
   return height;
 }
 
+int VideoFrame::GetPixelType() const { return pixel_type; }
+void VideoFrame::AmendPixelType(int new_pixel_type) { pixel_type = new_pixel_type; }
+
 // Generally you should not be using these two
 VideoFrameBuffer* VideoFrame::GetFrameBuffer() const { return vfb; }
 int VideoFrame::GetOffset(int plane) const {
@@ -1178,12 +1181,12 @@ static const AVS_Linkage avs_linkage = {   // struct AVS_Linkage {
 
   &VideoFrame::IsPropertyWritable,          //   V9
 
-  &VideoFrameBuffer::DESTRUCTOR,            //   void (VideoFrameBuffer::*VideoFrameBuffer_DESTRUCTOR)();
-
+  // V10
+  &VideoFrame::GetPixelType,                //   int          (VideoFrame::*VideoFrame_GetPixelType)() const;
+  &VideoFrame::AmendPixelType,              //   void         (VideoFrame::*VideoFrame_AmendPixelType)();
+  &VideoFrameBuffer::DESTRUCTOR,            //   void         (VideoFrameBuffer::*VideoFrameBuffer_DESTRUCTOR)();
   &AVSValue::GetType,                       //   AvsValueType (AVSValue::*AVSValue_GetType)() const;
 
-  NULL,                                     //   reserved for AviSynth+
-  NULL,                                     //   reserved for AviSynth+
   NULL,                                     //   reserved for AviSynth+
   NULL,                                     //   reserved for AviSynth+
   NULL,                                     //   reserved for AviSynth+

--- a/avs_core/filters/source.cpp
+++ b/avs_core/filters/source.cpp
@@ -507,13 +507,13 @@ PClip Create_MessageClip(const char* message, int width, int height, int pixel_t
                          IScriptEnvironment* env) {
   int size;
 #if defined(AVS_WINDOWS) && !defined(NO_WIN_GDI)
-    // MessageClip produces a clip containing a text message.Used internally for error reporting.
-    // The font face is "Arial".
-    // The font size is between 24 points and 9 points - chosen to fit, if possible,
-    // in the width by height clip.
-    // The pixeltype is RGB32.
+  // MessageClip produces a clip containing a text message.Used internally for error reporting.
+  // The font face is "Arial".
+  // The font size is between 24 points and 9 points - chosen to fit, if possible,
+  // in the width by height clip.
+  // The pixeltype is RGB32.
 
-    for (size = 24*8; /*size>=9*8*/; size-=4) {
+  for (size = 24*8; /*size>=9*8*/; size-=4) {
     int text_width, text_height;
     GetTextBoundingBox(message, "Arial", size, true, false, TA_TOP | TA_CENTER, &text_width, &text_height);
     text_width = ((text_width>>3)+8+7) & ~7; // mod 8

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -444,7 +444,7 @@ struct AVS_Linkage {
   // As of V8 most PDevice, PFunction linkage entries are moved to standard avs+ place.
   /**********************************************************************/
 
-  // this part should be identical with AVS_Linkage entries in interface.cpp
+  // This part should be identical with AVS_Linkage entries in interface.cpp
 };
 
 #if defined(BUILDING_AVSCORE) || defined(AVS_STATIC_LIB)
@@ -519,7 +519,7 @@ struct VideoInfo {
   int width, height;    // width 0 means no video
   unsigned fps_numerator, fps_denominator;
   int num_frames;
-  // This is more extensible than previous versions. More properties can be added seeminglesly.
+  // This is more extensible than previous versions. More properties can be added seamlessly.
 
   // Colorspace properties.
   /*
@@ -919,7 +919,7 @@ public:
 
 // Ensure VideoFrameBuffer cannot be publicly assigned
 private:
-    VideoFrameBuffer& operator=(const VideoFrameBuffer&);
+  VideoFrameBuffer& operator=(const VideoFrameBuffer&);
 
 #ifdef BUILDING_AVSCORE
 public:

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -665,7 +665,7 @@ typedef struct AVS_VideoFrameBuffer {
 
 // VideoFrame holds a "window" into a VideoFrameBuffer.
 
-// AVS_VideoFrame is laid out identically to IVideoFrame
+// AVS_VideoFrame is laid out identically to VideoFrame
 // DO NOT USE THIS STRUCTURE DIRECTLY
 typedef struct AVS_VideoFrame {
   volatile long refcount;
@@ -681,6 +681,7 @@ typedef struct AVS_VideoFrame {
   int offsetA;
   int pitchA, row_sizeA; // 4th alpha plane support, pitch and row_size is 0 is none
   void* properties; // frame properties
+  int pixel_type; // Copy from VideoInfo
 } AVS_VideoFrame;
 
 // Access functions for AVS_VideoFrame

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -1145,9 +1145,9 @@ typedef struct AVS_Library AVS_Library;
 // e.g. "AVSC_DECLARE_FUNC(avs_add_function);"
 // is a shortcut for "avs_add_function_func avs_add_function;"
 
-// Note: AVSC_INLINE functions which call into API,
-// are guarded by #ifndef AVSC_NO_DECLSPEC
-// They should call the appropriate library-> API entry
+// Note: AVSC_INLINE functions, which call into API,
+// are guarded by #ifndef AVSC_NO_DECLSPEC.
+// They should call the appropriate library-> API entry.
 
 struct AVS_Library {
   HMODULE handle;

--- a/distrib/Readme/readme_history.txt
+++ b/distrib/Readme/readme_history.txt
@@ -7,6 +7,9 @@ The "rst" version of the documentation just lists changes in brief.
 
 20230205 3.7.3 WIP
 ------------------
+- Feature (#317): The color format of a VideoFrame can now be retrieved with its GetPixelType()
+  function. Before, there was no reliable way of knowing it on a frame from propGetFrame().
+  (Also added AmendPixelType() for rare cases.)
 - Feature (#314): Added AVSValue::GetType()
 - "Text" new parameter: "placement" for chroma location hint
   - Used in subsampled YUV formats, otherwise ignored.

--- a/plugins/ConvertStacked/ConvertStacked.cpp
+++ b/plugins/ConvertStacked/ConvertStacked.cpp
@@ -303,7 +303,10 @@ public:
 
     PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment* env) override
     {
-        return child->GetFrame(n, env);
+        PVideoFrame frame = child->GetFrame(n, env);
+        env->MakeWritable(&frame);
+        frame->AmendPixelType(vi.pixel_type);
+        return frame;
     }
 
     int __stdcall SetCacheHints(int cachehints, int frame_range) override
@@ -341,7 +344,10 @@ public:
 
     PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment* env) override
     {
-        return child->GetFrame(n, env);
+        PVideoFrame frame = child->GetFrame(n, env);
+        env->MakeWritable(&frame);
+        frame->AmendPixelType(vi.pixel_type);
+        return frame;
     }
 
     int __stdcall SetCacheHints(int cachehints, int frame_range) override

--- a/plugins/ConvertStacked/ConvertStacked.cpp
+++ b/plugins/ConvertStacked/ConvertStacked.cpp
@@ -47,7 +47,6 @@ public:
 
     ConvertToStacked(PClip src, IScriptEnvironment* env) : GenericVideoFilter(src)
     {
-
         if (vi.IsColorSpace(VideoInfo::CS_YUV420P16)) vi.pixel_type = VideoInfo::CS_YV12;
         else if (vi.IsColorSpace(VideoInfo::CS_YUV422P16)) vi.pixel_type = VideoInfo::CS_YV16;
         else if (vi.IsColorSpace(VideoInfo::CS_YUV444P16)) vi.pixel_type = VideoInfo::CS_YV24;


### PR DESCRIPTION
Closes #317.

Don't forget to change the line in `struct AVS_Linkage` with the `TEMPORARY ENTRY` comment when resolving the conflict there that would happen anyway after merging #331.