### PR TITLE
fix "VarExists" typo

### DIFF
--- a/distrib/docs/english/source/avisynthdoc/syntax/syntax_internal_functions_boolean.rst
+++ b/distrib/docs/english/source/avisynthdoc/syntax/syntax_internal_functions_boolean.rst
@@ -179,11 +179,11 @@ Tests if the function, filter or property name is defined natively within AviSyn
 Unlike `FunctionExists`, returns false for external plugins and user-defined functions. 
 
 
-VarExists
+VarExist
 ---------
 ::
 
-    VarExists(string name)
+    VarExist(string name)
 
 Tests if the "name" variable exists or not.
 

--- a/distrib/docs/english/source/avisynthdoc/syntax/syntax_internal_functions_boolean.rst
+++ b/distrib/docs/english/source/avisynthdoc/syntax/syntax_internal_functions_boolean.rst
@@ -198,7 +198,7 @@ Changelog
 | Avisynth+      | | Added "IsFunction"             |
 |                | | Added "FunctionExists"         |
 |                | | Added "InternalFunctionExists" |
-|                | | Added "VarExists"              |
+|                | | Added "VarExist"               |
 +----------------+----------------------------------+
 
 Back to :doc:`Internal functions <syntax_internal_functions>`.


### PR DESCRIPTION
I've found a typo in the naming of the function `VarExist` in page [AviSynth Syntax - Boolean functions](https://avisynthplus.readthedocs.io/en/latest/avisynthdoc/syntax/syntax_internal_functions_boolean.html#varexists).

In case of doubts, please refer to the older wiki that follows the correct naming: http://avisynth.nl/index.php/Internal_functions#VarExist.