### PR TITLE
Fix when building with absolute paths

### DIFF
--- a/avs_core/avisynth.pc.in
+++ b/avs_core/avisynth.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/avisynth
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/avisynth
 
 Name: AviSynth+
 Description: A powerful nonlinear scripting language for video.

--- a/avs_core/avisynth_conf.h.in
+++ b/avs_core/avisynth_conf.h.in
@@ -5,7 +5,7 @@
 
 #ifdef AVS_POSIX
 #define user_avs_plugindir_configurable "@USER_AVS_PLUGINDIR_LOCATION@"
-#define system_avs_plugindir "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/avisynth"
+#define system_avs_plugindir "@CMAKE_INSTALL_FULL_LIBDIR@/avisynth"
 #endif
 
 #endif // _AVS_CONF_H_


### PR DESCRIPTION
When CMAKE_INSTALL_\<dir> is an absolute path the build fails, due to libdir and includedir being being created by concatenating prefix and  CMAKE_INSTALL_\<dir>, instead using CMAKE_INSTALL_FULL_\<dir> which check if CMAKE_INSTALL_\<dir> is an absolute path and if not concatenates it with CMAKE_INSTALL_PREFIX.

I encountered this issue while packing AviSynthPlus for nixpkgs.