### PR TITLE
Increased the maximum number of channels in SoundTouch from 16ch to 32ch

### DIFF
--- a/plugins/TimeStretch/SoundTouch/FIRFilter.cpp
+++ b/plugins/TimeStretch/SoundTouch/FIRFilter.cpp
@@ -170,7 +170,7 @@ uint FIRFilter::evaluateFilterMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, uin
     assert(src != NULL);
     assert(dest != NULL);
     assert(filterCoeffs != NULL);
-    assert(numChannels < 16);
+    assert(numChannels <= SOUNDTOUCH_MAX_CHANNELS);
 
     // hint compiler autovectorization that loop length is divisible by 8
     int ilength = length & -8;

--- a/plugins/TimeStretch/SoundTouch/STTypes.h
+++ b/plugins/TimeStretch/SoundTouch/STTypes.h
@@ -58,8 +58,9 @@ typedef unsigned long   ulong;
 
 namespace soundtouch
 {
-    /// Max allowed number of channels
-    #define SOUNDTOUCH_MAX_CHANNELS     16
+    /// Max allowed number of channels. This is not a hard limit but to have some
+    /// maximum value for argument sanity checks -- can be increased if necessary
+    #define SOUNDTOUCH_MAX_CHANNELS     32
 
     /// Activate these undef's to overrule the possible sampletype
     /// setting inherited from some other header file:


### PR DESCRIPTION
- Increased the max number of channels to 32ch from the old limit of 16ch.
- Removed the hardcoded 16ch check in FIRFilter.cpp to make it use the SOUNDTOUCH_MAX_CHANNELS variable defined in STTypes.h instead.

Both of those changes follow what was actually committed by Olli Parviainen, the SoundTouch maintainer, in the main repo: https://codeberg.org/soundtouch/soundtouch/commit/ddf28667c9f52f30573853c8177e77149829fa7c

This was tracked here as part of this conversation: https://codeberg.org/soundtouch/soundtouch/issues/38
