### PR TITLE
Fix mingwXX/ucrt64 redefinitions

### DIFF
--- a/avs_core/filters/AviSource/avi_source.cpp
+++ b/avs_core/filters/AviSource/avi_source.cpp
@@ -298,7 +298,7 @@ static PVideoFrame AdjustFrameAlignment(TemporalBuffer* frame, const VideoInfo& 
     return result;
 }
 
-#ifndef MSVC
+#if !defined(MSVC) && !defined(_WIN32)
 static __inline LRESULT
 ICDecompressEx(HIC hic,DWORD dwFlags,LPBITMAPINFOHEADER lpbiSrc,LPVOID lpSrc,INT xSrc,INT ySrc,INT dxSrc,INT dySrc,LPBITMAPINFOHEADER lpbiDst,LPVOID lpDst,INT xDst,INT yDst,INT dxDst,INT dyDst)
 {


### PR DESCRIPTION
mingwXX/ucrt64 `vfw.h` has already defined these.

Fixes #242 and https://github.com/AviSynth/AviSynthPlus/issues/342#issuecomment-1464720668