### PR TITLE
Fix mingwXX/ucrt64 redefinitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,7 @@ endif()
 
     if(WIN32)
       SET( CMAKE_SHARED_LINKER_FLAGS "-Wl,--enable-stdcall-fixup" )
+      SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -D__CRT__NO_INLINE=1" )
     elseif(APPLE)
       # macOS uses Clang's linker, doesn't like --no-undefined
       SET( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error" )


### PR DESCRIPTION
mingwXX/ucrt64 `vfw.h` has already defined these.
Fixes https://github.com/AviSynth/AviSynthPlus/issues/242 and https://github.com/AviSynth/AviSynthPlus/issues/342#issuecomment-1464720668.