### PR TITLE
Test GCC 15.0.0 20241020

### DIFF
--- a/avs_core/core/strings.h
+++ b/avs_core/core/strings.h
@@ -34,6 +34,7 @@
 
 #include <string>
 #include <memory>
+#include <cstdint>
 
 bool streqi(const char* s1, const char* s2);
 std::string concat(const std::string &s1, const std::string &s2);


### PR DESCRIPTION
In file included from strings.cpp:41:
strings.h:58:25: error: 'uint16_t' was not declared in this scope
   58 | std::string U16_to_utf8(uint16_t u16);
      |                         ^~~~~~~~
strings.h:37:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   36 | #include <memory>
  +++ |+#include <cstdint>
   37 |
strings.cpp:240:13: error: redefinition of 'std::string U16_to_utf8'
  240 | std::string U16_to_utf8(uint16_t u16)
      |             ^~~~~~~~~~~
strings.h:58:13: note: 'std::string U16_to_utf8' previously declared here
   58 | std::string U16_to_utf8(uint16_t u16);
      |             ^~~~~~~~~~~
strings.cpp:240:25: error: 'uint16_t' was not declared in this scope
  240 | std::string U16_to_utf8(uint16_t u16)
      |                         ^~~~~~~~
strings.cpp:48:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   47 | #include <vector>
  +++ |+#include <cstdint>