### PR TITLE
Add LoongArch support

### DIFF
--- a/avs_core/include/avs/config.h
+++ b/avs_core/include/avs/config.h
@@ -59,6 +59,8 @@
 #   define PPC32
 #elif defined(__riscv)
 #   define RISCV
+#elif defined(__loongarch__)
+#   define LOONGARCH
 #elif defined(__sparc_v9__)
 #   define SPARC
 #elif defined(__mips__)


### PR DESCRIPTION
[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

This PR adds the support of LoongArch. I've tested it with Arch Linux's loong64 port, and the build process **succeeded**. ([view the log](https://gist.github.com/wszqkzqk/d551c8c86aaa8e786b236bb69d51a3c2))