### PR TITLE
Include `<chrono>` for high_resolution_clock

### DIFF
--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -45,6 +45,7 @@
 #include "FilterConstructor.h"
 #include "PluginManager.h"
 #include "MappedList.h"
+#include <chrono>
 #include <vector>
 #include <iostream>
 #include <fstream>

--- a/avs_core/core/cache.cpp
+++ b/avs_core/core/cache.cpp
@@ -38,6 +38,7 @@
 #include "InternalEnvironment.h"
 #include "DeviceManager.h"
 #include <cassert>
+#include <chrono>
 #include <cstdio>
 
 #ifdef X86_32


### PR DESCRIPTION
I am a member of Microsoft vcpkg, due to there are new changes merged by microsoft/STL#5105, which revealed a conformance issue in `AviSynthPlus`. It must add include `<chrono>` to fix this error.

Compiler error with this STL change:
```
D:\b\avisynthplus\src\v3.7.3-01e1867324.clean\avs_core\core\cache.cpp(181): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
D:\b\avisynthplus\src\v3.7.3-01e1867324.clean\avs_core\core\avisynth.cpp(911): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
```