### PR TITLE
Added strlen

### DIFF
--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -458,7 +458,7 @@ bool AVSFunction::ArgNameMatch(const char* param_types, size_t args_names_count,
           p += 1;
           const char* q = strchr(p, ']');
           if (!q) return false;
-          if (len == q-p && !_strnicmp(arg_names[i], p, q-p)) {
+          if ((len == strlen(q-p)) && !_strnicmp(arg_names[i], p, q-p)) {
             found = true;
             break;
           }

--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -458,7 +458,7 @@ bool AVSFunction::ArgNameMatch(const char* param_types, size_t args_names_count,
           p += 1;
           const char* q = strchr(p, ']');
           if (!q) return false;
-          if ((len == strlen((const char*)(q-p))) && !_strnicmp(arg_names[i], p, q-p)) {
+          if ((len == strlen((const char*)(q-p))) && !_strnicmp(arg_names[i], p, strlen((const char*)(q-p)))) {
             found = true;
             break;
           }

--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -458,7 +458,7 @@ bool AVSFunction::ArgNameMatch(const char* param_types, size_t args_names_count,
           p += 1;
           const char* q = strchr(p, ']');
           if (!q) return false;
-          if ((len == strlen(q-p)) && !_strnicmp(arg_names[i], p, q-p)) {
+          if ((len == strlen((const char*)(q-p))) && !_strnicmp(arg_names[i], p, q-p)) {
             found = true;
             break;
           }

--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -4596,7 +4596,7 @@ bool ScriptEnvironment::Invoke_(AVSValue *result, const AVSValue& implicit_last,
           p += 1;
           const char* q = strchr(p, ']');
           if (!q) break;
-          if (strlen(arg_names[i]) == size_t(q - p) && !_strnicmp(arg_names[i], p, q - p)) {
+          if ((strlen(arg_names[i]) == strlen((const char*)(q-p))) && !_strnicmp(arg_names[i], p, strlen((const char*)(q-p))) {
             // we have a match
             if (args3[named_arg_index].Defined() && args3_really_filled[named_arg_index]) {
               // when a parameter like named array was filled as an empty array


### PR DESCRIPTION
```
PluginManager.cpp:461:19: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long long unsigned int'} and 'long long int' [-Wsign-compare]
  461 |           if (len == q-p && !_strnicmp(arg_names[i], p, q-p)) {
      |               ~~~~^~~~~~
```