### PR TITLE
Fix missing semicolon in C header

### DIFF
--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -1622,7 +1622,7 @@ struct AVS_Library {
   AVSC_DECLARE_FUNC(avs_set_to_array);
   AVSC_DECLARE_FUNC(avs_set_to_void);
   // getters for all basic types. note: avs_get_as_float returns double
-  AVSC_DECLARE_FUNC(avs_get_as_error)
+  AVSC_DECLARE_FUNC(avs_get_as_error);
   AVSC_DECLARE_FUNC(avs_get_as_array);
   AVSC_DECLARE_FUNC(avs_get_as_bool);
   AVSC_DECLARE_FUNC(avs_get_as_clip);


### PR DESCRIPTION
Fixes:

```
/opt/ffbuild/include/avisynth/avisynth_c.h:1915:22: error: no member named 'avs_get_as_array' in 'struct AVS_Library'
 1915 |   AVSC_LOAD_FUNC_OPT(avs_get_as_array);
      |   ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/opt/ffbuild/include/avisynth/avisynth_c.h:1715:52: note: expanded from macro 'AVSC_LOAD_FUNC_OPT'
 1715 | #define AVSC_LOAD_FUNC_OPT(name) AVSC_DO_LOAD_FUNC(name, 1)
      |                                  ~~~~~~~~~~~~~~~~~~^~~~~~~~
/opt/ffbuild/include/avisynth/avisynth_c.h:1710:12: note: expanded from macro 'AVSC_DO_LOAD_FUNC'
 1710 |   library->name = (name##_func) GetProcAddress(library->handle, AVSC_STRINGIFY(name));\
      |   ~~~~~~~  ^
/opt/ffbuild/include/avisynth/avisynth_c.h:1915:22: error: no member named 'avs_get_as_array' in 'struct AVS_Library'
 1915 |   AVSC_LOAD_FUNC_OPT(avs_get_as_array);
      |   ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/opt/ffbuild/include/avisynth/avisynth_c.h:1715:52: note: expanded from macro 'AVSC_LOAD_FUNC_OPT'
 1715 | #define AVSC_LOAD_FUNC_OPT(name) AVSC_DO_LOAD_FUNC(name, 1)
      |                                  ~~~~~~~~~~~~~~~~~~^~~~~~~~
/opt/ffbuild/include/avisynth/avisynth_c.h:1711:34: note: expanded from macro 'AVSC_DO_LOAD_FUNC'
 1711 |   if (!allow_missing && library->name == NULL)\
      |                         ~~~~~~~  ^
```