### PR TITLE
Fix GCC warnings

### DIFF
--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -964,7 +964,7 @@ struct AVS_Value {
 // Should also set to avs_void after the value is released
 // with avs_copy_value.  Consider it the equivalent of setting
 // a pointer to NULL
-static const AVS_Value avs_void = {'v'};
+static const AVS_Value avs_void = {'v', 0, {0}};
 // see also avs_set_to_void v11 API
 
 /*******************************


### PR DESCRIPTION
I use [external dynamic loader](https://github.com/Asd-g/avisynthplus-c-api-dynamic-loader) (C API).
I don't use `avs_load_library()` at all but compiler still parsing it and gives warnings (see the attached log).
If I define `EXTERNAL_AVS_C_API_LOADER` in my loader I can avoid all of these warnings.


There is one other warning from `avisynth_c.h` not related to the above case.

```
D:/a/_temp/msys64/mingw64/include/avisynth/avisynth_c.h:967:39: warning: missing initializer for member 'AVS_Value::array_size' [-Wmissing-field-initializers]
967 | static const AVS_Value avs_void = {'v'};
```

[0_build-windows.zip](https://github.com/user-attachments/files/20402383/0_build-windows.zip)
