### PR TITLE
[WIP] Cache: Avoid naming collision

### DIFF
--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -1070,7 +1070,7 @@ private:
   typedef std::vector<DebugTimestampedFrame> VideoFrameArrayType;
   typedef std::map<VideoFrameBuffer *, VideoFrameArrayType> FrameBufferRegistryType;
   typedef std::map<size_t, FrameBufferRegistryType> FrameRegistryType2; // post r1825 P.F.
-  typedef mapped_list<Cache*> CacheRegistryType;
+  typedef mapped_list<AvsCache*> CacheRegistryType;
 
 
   FrameRegistryType2 FrameRegistry2; // P.F.
@@ -1080,7 +1080,7 @@ private:
 
   std::unique_ptr<DeviceManager> Devices;
   CacheRegistryType CacheRegistry;
-  Cache* FrontCache;
+  AvsCache* FrontCache;
   VideoFrame* GetNewFrame(size_t vfb_size, size_t margin, Device* device);
   VideoFrame* GetFrameFromRegistry(size_t vfb_size, Device* device);
   void ShrinkCache(Device* device);
@@ -3605,7 +3605,7 @@ VideoFrame* ScriptEnvironment::GetNewFrame(size_t vfb_size, size_t margin, Devic
   for (auto &cit: CacheRegistry)
   {
     cache_counter++;
-    Cache* cache = cit;
+    AvsCache* cache = cit;
     int cache_size = cache->SetCacheHints(CACHE_GET_SIZE, 0);
     _RPT4(0, "  cache#%d cache_ptr=%p cache_size=%d \n", cache_counter, (void*)cache, cache_size); // let's see what's in the cache
   }
@@ -3729,7 +3729,7 @@ void ScriptEnvironment::ShrinkCache(Device *device)
 
     // We try to shrink least recently used caches first.
 
-    Cache* cache = cit;
+    AvsCache* cache = cit;
     if (cache->GetDevice() != device) {
       continue;
     }
@@ -4206,7 +4206,7 @@ void* ScriptEnvironment::ManageCache(int key, void* data) {
     // Called by Cache instances upon creation
   case MC_RegisterCache:
   {
-    Cache* cache = reinterpret_cast<Cache*>(data);
+    AvsCache* cache = reinterpret_cast<AvsCache*>(data);
     if (FrontCache != NULL)
       CacheRegistry.push_back(FrontCache);
     FrontCache = cache;
@@ -4215,7 +4215,7 @@ void* ScriptEnvironment::ManageCache(int key, void* data) {
   // Called by Cache instances upon destruction
   case MC_UnRegisterCache:
   {
-    Cache* cache = reinterpret_cast<Cache*>(data);
+    AvsCache* cache = reinterpret_cast<AvsCache*>(data);
     if (FrontCache == cache)
       FrontCache = NULL;
     else
@@ -4225,7 +4225,7 @@ void* ScriptEnvironment::ManageCache(int key, void* data) {
   // Called by Cache instances when they want to expand their limit
   case MC_NodAndExpandCache:
   {
-    Cache* cache = reinterpret_cast<Cache*>(data);
+    AvsCache* cache = reinterpret_cast<AvsCache*>(data);
 
     // Nod
     if (cache != FrontCache)
@@ -4249,7 +4249,7 @@ void* ScriptEnvironment::ManageCache(int key, void* data) {
       // If we don't have enough free reserves, take away a cache slot from
       // a cache instance that hasn't been used since long.
 
-      for (Cache* old_cache : CacheRegistry)
+      for (AvsCache* old_cache : CacheRegistry)
       {
         if (old_cache->GetDevice() != device) {
           continue;
@@ -4272,7 +4272,7 @@ void* ScriptEnvironment::ManageCache(int key, void* data) {
   // Called by Cache instances when they are accessed
   case MC_NodCache:
   {
-    Cache* cache = reinterpret_cast<Cache*>(data);
+    AvsCache* cache = reinterpret_cast<AvsCache*>(data);
     if (cache == FrontCache) {
       return 0;
     }
@@ -5127,11 +5127,11 @@ bool ScriptEnvironment::Invoke_(AVSValue *result, const AVSValue& implicit_last,
 #ifdef _DEBUG
     if (PrevFrontCache != FrontCache && FrontCache != NULL) // cache registering swaps frontcache to the current
     {
-      _RPT2(0, "ScriptEnvironment::Invoke done Cache::Create %s  cache_id=%p\r\n", name, (void*)FrontCache);
+      _RPT2(0, "ScriptEnvironment::Invoke done AvsCache::Create %s  cache_id=%p\r\n", name, (void*)FrontCache);
       FrontCache->FuncName = name; // helps debugging. See also in cache.cpp
     }
     else {
-      _RPT1(0, "ScriptEnvironment::Invoke done Cache::Create %s\r\n", name);
+      _RPT1(0, "ScriptEnvironment::Invoke done AvsCache::Create %s\r\n", name);
     }
 #endif
   }

--- a/avs_core/core/cache.h
+++ b/avs_core/core/cache.h
@@ -43,7 +43,7 @@
 struct CachePimpl;
 class InternalEnvironment;
 
-class Cache : public IClip
+class AvsCache : public IClip
 {
 private:
 
@@ -58,8 +58,8 @@ public:
 #ifdef _DEBUG
   std::string FuncName = ""; // P.F. Invoked function's name whose queue owns the cache object
 #endif
-  Cache(const PClip& child, Device* device, std::mutex &CacheGuardMutex, InternalEnvironment* env);
-  ~Cache();
+  AvsCache(const PClip& child, Device* device, std::mutex &CacheGuardMutex, InternalEnvironment* env);
+  ~AvsCache();
   PVideoFrame __stdcall GetFrame(int n, IScriptEnvironment* env);
   void __stdcall GetAudio(void* buf, int64_t start, int64_t count, IScriptEnvironment* env);
   const VideoInfo& __stdcall GetVideoInfo();

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -1007,7 +1007,7 @@ class VideoFrameBuffer {
   volatile long sequence_number;
 
   friend class VideoFrame;
-  friend class Cache;
+  friend class AvsCache;
   friend class ScriptEnvironment;
   volatile long refcount;
 
@@ -1101,7 +1101,7 @@ class VideoFrame {
   void Release();
 
   friend class ScriptEnvironment;
-  friend class Cache;
+  friend class AvsCache;
 
   VideoFrame(VideoFrameBuffer* _vfb, AVSMap* avsmap, int _offset, int _pitch, int _row_size, int _height, int _pixel_type);
   VideoFrame(VideoFrameBuffer* _vfb, AVSMap* avsmap, int _offset, int _pitch, int _row_size, int _height, int _offsetU, int _offsetV, int _pitchUV, int _row_sizeUV, int _heightUV, int _pixel_type);


### PR DESCRIPTION
See: https://ffmpeg.org/pipermail/ffmpeg-devel/2025-July/347178.html

When AviSynth+ and libvmaf are both enabled in FFmpeg, there's a collision between identically-named objects/classes named Cache, leading to a segfault on exit.  The proposed solution there is to adjust how dlopen resolves symbols (moving from `RTLD_LOCAL` to `RTLD_DEEPBIND`), but this is largely a band-aid and not a real fix.  Making sure we're not using generic names for high-level exported objects is the actual fix.

So with that in mind, I simply shifted the naming to AvsCache, and that appears to fix *this* particular problem on a cursory test.  I don't know if it happens anywhere else, or if there are other things we're going to need to rename.

This is labeled as WIP because while this resolved the issue in FFmpeg, what I am absolutely not sure about is whether this constitutes some sort of breakage on the plugin side, which needs to be investigated more.  At least on Linux, it didn't seem to cause a problem with either ImageSeq or FFMS2, and if the Cache class as it exists in `avs_core/core/cache.{h,cpp}` is truly something internal to the core, I would *hope* that plugin authors aren't trying to access it, but I obviously can never be sure.

From what I could tell, it's most noticeable when dealing with shared libraries, as I don't think I was able to reproduce it on Windows with a Gyan build of FFmpeg where libvmaf was linked statically.