### PR TITLE
Using UTF-8 in the return string of GetLastErrorText

### DIFF
--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -79,7 +79,8 @@ static std::string GetLastErrorText(DWORD nErrorCode)
     return("Unknown error");
   else
   {
-    std::string ret(msg);
+    auto msg_utf8 = AnsiToUtf8(msg);
+    std::string ret(msg_utf8.get());
     LocalFree(msg);
     return ret;
   }


### PR DESCRIPTION
Avisinth+ writes errors to `AvisynthError::msg` in UTF-8 format. However, Avisinth+ receives system error text in ANSI (CP_ACP) format and stores it in `AvisynthError::msg`. The result is an error text with two encodings for different lines.

A simple example:
Create a script file named "Duck_Утка_Πάπια_오리.avs" and add one line to it:
`LoadPlugin ("filename")`
The file "filename" won't be found, and we'll see the following error message:
```
Cannot load file 'C:/TEMP/filename'. Platform returned code 126:
�� ������ ��������� ������.

(C:\TEMP\Duck_Утка_Πάπια_오리.avs, line 1)
```
So I changed GetLastErrorText so it returns a UTF-8 encoded string.