### PR TITLE
Implement container-based development environment

### DIFF
--- a/dev-assets/.gitignore
+++ b/dev-assets/.gitignore
@@ -1,0 +1,7 @@
+# Copyright 2026 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>
+# SPDX-License-Identifier: CC-BY-SA-3.0
+
+# Debian packaging artifacts
+*.buildinfo
+*.changes
+*.deb

--- a/dev-assets/README.md
+++ b/dev-assets/README.md
@@ -1,0 +1,63 @@
+# dev-assets
+
+This directory contains various assets used in the development of the project.
+
+## How to develop in an isolated environment
+
+Refer to the following instructions to set up an isolated development environment:
+
+### Prerequisites
+
+Install [Docker](https://www.docker.com/get-started) on your machine.
+
+### Process
+
+Refer to the steps below to set up and access the isolated development environment:
+
+1. Open a terminal and navigate to the root directory of the project.
+1. Change the working directory to `dev-assets`:
+
+   ```bash
+   cd dev-assets
+   ```
+
+1. Run the following command to create the development environment container:
+
+   ```bash
+   docker compose up -d
+   ```
+
+1. Run the following command to access the container's shell:
+
+   ```bash
+   docker container exec -it avisynthplus-dev bash --login
+   ```
+
+1. If you like to use a local Ubuntu archive mirror, run the following command:
+
+   ```bash
+   sed -i --regexp-extended 's@archive\.@CCTLD\.archive\.@' /etc/apt/sources.list.d/ubuntu.sources
+   ```
+
+   Replace `CCTLD` with your country's top-level domain (e.g., `us`, `de`, `fr`, etc.).
+1. Run the following command to refresh the package index inside the container:
+
+   ```bash
+   apt update
+   ```
+
+1. Run the following command to install the dependencies required for building the build dependencies package:
+
+   ```bash
+   apt install -y equivs
+   ```
+
+1. Run the following commands to build and install the build dependencies metapackage:
+
+   ```bash
+   cd /project/dev-assets
+   equivs-build dev-assets/avisynthplus.ctl
+   apt install ./avisynthplus-build-deps_1.0_all.deb
+   ```
+
+   You can now proceed with the regular building instructions in [the main project README](../README.md), the project files are mounted at `/project`.

--- a/dev-assets/avisynthplus.ctl
+++ b/dev-assets/avisynthplus.ctl
@@ -1,0 +1,22 @@
+# Equivs control file for building the build dependencies meta-package
+#
+# Copyright 2026 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>
+# SPDX-License-Identifier: CC-BY-SA-3.0
+Source: avisynthplus
+Section: misc
+Priority: optional
+Homepage: https://github.com/AviSynth/AviSynthPlus
+Standards-Version: 3.9.2
+
+Package: avisynthplus-build-deps
+Depends:
+ cmake,
+ git,
+ g++,
+ libdevil-dev,
+ libsoundtouch-dev,
+ pkg-config,
+ python3-sphinx
+Description: Meta-package for the build dependencies of AviSynth+
+ This allows clean removal of the build dependency packages after they
+ are no longer used.

--- a/dev-assets/compose.yml
+++ b/dev-assets/compose.yml
@@ -1,0 +1,33 @@
+# Compose configuration file
+#
+# References:
+#
+# * Compose Specification | Compose file reference | Reference | Docker Docs
+#   https://docs.docker.com/compose/compose-file/
+#
+# Copyright 2026 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>
+# SPDX-License-Identifier: CC-BY-SA-3.0
+name: avisynthplus
+services:
+  # Environment for developing the project
+  dev-environment:
+    container_name: avisynthplus-dev
+    hostname: avisynthplus-dev
+    image: ubuntu:24.04
+    volumes:
+      - type: bind
+        source: ../
+        target: /project
+    environment:
+      # Pass host proxy settings to the container
+      - http_proxy
+      - HTTP_PROXY
+      - https_proxy
+      - HTTPS_PROXY
+      - no_proxy
+      - NO_PROXY
+
+      # Avoid debconf interactive prompts on Debian-like systems
+      - DEBIAN_FRONTEND=noninteractive
+    init: true
+    command: sleep infinity


### PR DESCRIPTION
This patch implements Ubuntu 24.04 container-based development environment for testing patches in an isolated environment.

It includes a compose file to create and launch an OCI container, a Equivs control file for building the build dependencies meta-package for Avisynth+, and a README document that explains how to make use of them.

This pull request is mostly just a byproduct of my patch-testing process; feel free to close it if it doesn't help/make sense in this project.