### PR TITLE
internal.h: wrap x86intrin.h in extern "C"

### DIFF
--- a/avs_core/core/internal.h
+++ b/avs_core/core/internal.h
@@ -53,8 +53,10 @@
 // Intrinsics base header + really required extension headers
 #if defined(_MSC_VER)
 #include <intrin.h> // MSVC, Clang-CL, and Intel C++ (in MSVC mode)
-#else 
-#include <x86intrin.h> // GCC/MinGW, Clang (Linux/GNU mode), and Intel C++ (in non-MSVC mode) (__GNUC__, __clang__, __INTEL_COMPILER, etc.)
+#else
+extern "C" {
+    #include <x86intrin.h> // GCC/MinGW, Clang (Linux/GNU mode), and Intel C++ (in non-MSVC mode) (__GNUC__, __clang__, __INTEL_COMPILER, etc.)
+}
 #endif
 #include <emmintrin.h> // SSE2
 #include <tmmintrin.h> // SSSE3


### PR DESCRIPTION
Avoids build failure when cross-compiling for i686 with MinGW/GCC.

I didn't just go ahead and push this only because I'm not sure if the actual cause of the issue is somewhere else, and the fix should be resolved in a different way (especially since there are plenty of other places where we include `x86intrin.h` and it doesn't need this).  This is just what worked in the moment.

I'm also not sure when this broke, the last time I ran through the cross compile guide I'm pretty sure it worked.