### PR TITLE
[WIP] Refactor and fix C++ interface outside x86

### DIFF
--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -115,6 +115,12 @@
 #define __cdecl
 #endif
 
+// Use C-style linkage on Windows if targetting any CPU architecture
+// other than legacy x86
+#if defined(AVS_WINDOWS) && !defined(AVS_WINDOWS_X86)
+extern "C" {
+#endif
+
 // Important note on AVISYNTH_INTERFACE_VERSION V6->V8 change:
 // Note 1: Those few plugins which were using earlier IScriptEnvironment2 despite the big Warning will crash have to be rebuilt.
 // Note 2: How to support earlier avisynth interface with an up-to-date avisynth.h:
@@ -2053,5 +2059,9 @@ AVSC_API(IScriptEnvironment2*, CreateScriptEnvironment2)(int version = AVISYNTH_
 #endif
 
 #pragma pack(pop)
+
+#if defined(AVS_WINDOWS) && !defined(AVS_WINDOWS_X86)
+}
+#endif // extern "C"
 
 #endif //__AVISYNTH_12_H__

--- a/avs_core/include/avisynth.h
+++ b/avs_core/include/avisynth.h
@@ -100,6 +100,7 @@
 
 #include "avs/config.h"
 #include "avs/capi.h"
+#include "avs/cpuid.h"
 #include "avs/types.h"
 
 #ifdef AVS_POSIX
@@ -113,12 +114,6 @@
 #endif
 #define __stdcall
 #define __cdecl
-#endif
-
-// Use C-style linkage on Windows if targetting any CPU architecture
-// other than legacy x86
-#if defined(AVS_WINDOWS) && !defined(AVS_WINDOWS_X86)
-extern "C" {
 #endif
 
 // Important note on AVISYNTH_INTERFACE_VERSION V6->V8 change:
@@ -171,7 +166,17 @@ enum AvsVersion {
   #define _ASSERT(x) assert(x)
 #endif
 
+#if defined(BUILDING_AVSCORE) || defined(AVS_STATIC_LIB)
+# ifndef offsetof
+#  include <stddef.h>
+# endif
+#endif
 
+// Use C-style linkage on Windows if targetting any CPU architecture
+// other than legacy x86
+#if defined(AVS_WINDOWS) && !defined(AVS_WINDOWS_X86)
+extern "C" {
+#endif
 
 // I had problems with Premiere wanting 1-byte alignment for its structures,
 // so I now set the Avisynth struct alignment explicitly here.
@@ -514,10 +519,6 @@ struct AVS_Linkage {
 extern __declspec(dllimport) const AVS_Linkage* const AVS_linkage;
 # else
 extern const AVS_Linkage* AVS_linkage;
-# endif
-
-# ifndef offsetof
-#  include <stddef.h>
 # endif
 
 # define AVS_BakedCode(arg) { arg ; }
@@ -1531,8 +1532,6 @@ public:
 #undef AVS_BakedCode
 
 
-#include "avs/cpuid.h"
-
 // IScriptEnvironment GetEnvProperty
 enum AvsEnvProperty {
   AEP_PHYSICAL_CPUS = 1,
@@ -2051,7 +2050,6 @@ AVSC_API(IScriptEnvironment*, CreateScriptEnvironment)(int version = AVISYNTH_IN
 #define VARNAME_Enable_PlanarToPackedRGB "OPT_Enable_PlanarToPackedRGB" // AVS+ convert Planar RGB to packed RGB (VfW)
 
 // C exports
-#include "avs/capi.h"
 AVSC_API(IScriptEnvironment2*, CreateScriptEnvironment2)(int version = AVISYNTH_INTERFACE_VERSION);
 
 #ifndef BUILDING_AVSCORE


### PR DESCRIPTION
The C++ ABI compatibility problems on x86 are something I absolutely want to avoid propagating outside of x86.  That was the reason I initially disabled MSVC from being used if targetting ARM.  We have other options, though, all of which are intrinsically more difficult than just requiring a compiler that adheres to the Itanium C++ ABI scheme.  Hell, if clang-cl was able to be switched into Itanium mode and just be a means of using Clang from within the MSVC IDE with existing MSVC projects, that would be the simplest option.  But I can't find ***any*** indication that such a thing is possible from the documentation and Google searches.

Which means we need to do the hard thing that honestly, we've been needing to do for a long time anyway.

Ultimately, the only way out of this is that the C++ interface must be fundamentally changed to use C linkage, because then the issue of compatibility shifts mostly to plugins - they can paper over the minor name-mangling issues that still exist between implementations (or we can allow for that flexibility in the plugin loader), and avoid using problematic features like exceptions being thrown across incompatible boundaries and so on.

The existing C++ interface would remain the way it is.  On x86, nothing changes.  On ARM, the old C++ interface is disabled in favor of the fixed one.  The fixed C++ interface would have its identifier changed so that any plugins using it are considered a separate plugin type.  That way, once the kinks have been worked out, we could enable it even on x86.

The bigger details of how to do that fixing is a much larger target (see my next post), but the one thing that all of them start with is wrapping the C++ interface in `extern "C"`, and to do so only on ARM.

The `extern "C"` is guarded behind ifdefs detecting x86 Windows vs. !x86 Windows, and cross-compilation succeeds with amd64 and i686 builds, as well as working as usual for non-Windows targets.  The first thing to fix here is that the aarch64/Windows cross target fails at the linking phase, with the following errors:

```
$ cmake ../../ -G "Ninja" -DCMAKE_INSTALL_PREFIX=/usr/aarch64-w64-mingw32 \
    -DCMAKE_TOOLCHAIN_FILE="/usr/llvm-mingw/aarch64-w64-mingw32/toolchain-aarch64-w64-mingw32.cmake" \
    -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_PREFIX_PATH=/usr/aarch64-w64-mingw32 \
    -DCMAKE_STAGING_PREFIX=/usr/aarch64-w64-mingw32 -DCMAKE_CXX_FLAGS="-DIL_STATIC_LIB" \
    -DIL_LIBRARIES="/usr/aarch64-w64-mingw32/lib/libIL.a;/usr/aarch64-w64-mingw32/lib/libturbojpeg.a;\
/usr/aarch64-w64-mingw32/lib/libpng18.a;/usr/aarch64-w64-mingw32/lib/libtiff.a;\ 
/usr/aarch64-w64-mingw32/lib/libsquish.a;/usr/aarch64-w64-mingw32/lib/libjasper.a;\
/usr/aarch64-w64-mingw32/lib/libz.a;/usr/aarch64-w64-mingw32/lib/liblzma.a;\
/usr/aarch64-w64-mingw32/lib/libjbig.a;/usr/aarch64-w64-mingw32/lib/libLerc.a;\
/usr/aarch64-w64-mingw32/lib/libzstd.a;/usr/aarch64-w64-mingw32/lib/libdeflate.a;\
/usr/llvm-mingw/aarch64-w64-mingw32/lib/libpthread.a" \
    -DILU_LIBRARIES=/usr/aarch64-w64-mingw32/lib/libILU.a
-- The CXX compiler identification is Clang 21.1.3
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/llvm-mingw/bin/aarch64-w64-mingw32-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Target is aarch64, turn NEON_SIMD ON.
-- Build type: Release
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE
-- The C compiler identification is Clang 21.1.3
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/llvm-mingw/bin/aarch64-w64-mingw32-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Git: /usr/bin/git (found version "2.51.0")
-- Found DevIL: /usr/aarch64-w64-mingw32/lib/libIL.a;/usr/aarch64-w64-mingw32/lib/libturbojpeg.a;/usr/aarch64-w64-mingw32/lib/libpng18.a;/usr/aarch64-w64-mingw32/lib/libtiff.a;/usr/aarch64-w64-mingw32/lib/libsquish.a;/usr/aarch64-w64-mingw32/lib/libjasper.a;/usr/aarch64-w64-mingw32/lib/libz.a;/usr/aarch64-w64-mingw32/lib/liblzma.a;/usr/aarch64-w64-mingw32/lib/libjbig.a;/usr/aarch64-w64-mingw32/lib/libLerc.a;/usr/aarch64-w64-mingw32/lib/libzstd.a;/usr/aarch64-w64-mingw32/lib/libdeflate.a;/usr/llvm-mingw/aarch64-w64-mingw32/lib/libpthread.a
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1")
-- Checking for module 'soundtouch'
--   Found soundtouch, version 2.4.0
Found DevIL library: /usr/aarch64-w64-mingw32/lib/libIL.a;/usr/aarch64-w64-mingw32/lib/libturbojpeg.a;/usr/aarch64-w64-mingw32/lib/libpng18.a;/usr/aarch64-w64-mingw32/lib/libtiff.a;/usr/aarch64-w64-mingw32/lib/libsquish.a;/usr/aarch64-w64-mingw32/lib/libjasper.a;/usr/aarch64-w64-mingw32/lib/libz.a;/usr/aarch64-w64-mingw32/lib/liblzma.a;/usr/aarch64-w64-mingw32/lib/libjbig.a;/usr/aarch64-w64-mingw32/lib/libLerc.a;/usr/aarch64-w64-mingw32/lib/libzstd.a;/usr/aarch64-w64-mingw32/lib/libdeflate.a;/usr/llvm-mingw/aarch64-w64-mingw32/lib/libpthread.a
-- Applying compiler fixes to target: AvsCore
-- Configuring done (1.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/qyot27/mpv-build-deps/AviSynthPlus/avisynth-build/aarch64

$ ninja
[1/101] cd /home/qyot27/mpv-build-deps...ps/AviSynthPlus/avs_core/Version.cmake
-- Found Git: /usr/bin/git (found version "2.51.0")
[101/101] Linking CXX shared library avs_core/AviSynth.dll
FAILED: avs_core/AviSynth.dll avs_core/AviSynth.dll.a 
: && /usr/llvm-mingw/bin/aarch64-w64-mingw32-g++ -DIL_STATIC_LIB -O3 -DNDEBUG  -Wl,--enable-stdcall-fixup -shared -o avs_core/AviSynth.dll -Wl,--out-implib,avs_core/AviSynth.dll.a -Wl,--major-image-version,0,--minor-image-version,0 avs_core/CMakeFiles/AvsCore.dir/convert/convert.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_audio.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_audio_c.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_bits.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_helper.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_matrix.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_planar.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_rgb.cpp.obj avs_core/CMakeFiles/AvsCore.dir/convert/convert_yuy2.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/AviHelper.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/BufferPool.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/DeviceManager.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/FilterConstructor.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/FilterGraph.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/MTGuard.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/PluginManager.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/Prefetcher.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/ThreadPool.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/alignplanar.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/audio.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/avisynth.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/avisynth_c.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/bitblt.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/cache.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/cpuid.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/exception.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/fonts/fixedfonts.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/info.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/initguid.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/interface.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/main.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/memcpy_amd.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/parser/expression.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/parser/script.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/parser/scriptparser.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/parser/tokenizer.cpp.obj avs_core/CMakeFiles/AvsCore.dir/core/strings.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/color.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/combine.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/conditional/conditional.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/conditional/conditional_functions.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/conditional/conditional_reader.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/convolution.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/debug.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/edit.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/exprfilter/exprfilter.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/field.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/focus.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/fps.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/greyscale.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/histogram.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/layer.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/levels.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/limiter.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/merge.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/misc.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/444convert.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/OF_add.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/OF_blend.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/OF_darken.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/OF_difference.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/OF_exclusion.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/OF_multiply.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/OF_softhardlight.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/blend_common.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/overlay/overlay.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/planeswap.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/resample.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/resample_functions.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/resize.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/source.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/text-overlay.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/transform.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/turn.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/aarch64/turn_neon.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/AVIIndex.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/AVIReadHandler.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/AudioSource.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/DubSource.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/FastReadStream.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/File64.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/VD_Audio.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/avi_source.cpp.obj avs_core/CMakeFiles/AvsCore.dir/filters/AviSource/list.cpp.obj  -luuid  -lwinmm  -lvfw32  -lmsacm32  -lgdi32  -luser32  -ladvapi32  -lole32  -limagehlp  -lpthread  -lc++ && :
ld.lld: error: undefined symbol: GetCPUFlagsEx
>>> referenced by avs_core/CMakeFiles/AvsCore.dir/core/avisynth.cpp.obj:(ScriptEnvironment::ScriptEnvironment())

ld.lld: error: undefined symbol: GetL2CacheSize
>>> referenced by avs_core/CMakeFiles/AvsCore.dir/core/avisynth.cpp.obj:(ScriptEnvironment::ScriptEnvironment())
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

I tried looking at comparable functions near or similar to both of these, and I can't figure out why they're being lost as undefined.