### PR TITLE
Fix: define memcpy

### DIFF
--- a/avs_core/filters/overlay/blend_common.cpp
+++ b/avs_core/filters/overlay/blend_common.cpp
@@ -40,6 +40,7 @@
 #include "overlayfunctions.h"
 
 #include <stdint.h>
+#include <cstring>
 #include <type_traits>
 
 


### PR DESCRIPTION
```
blend_common.cpp: In function 'void weighted_merge_return_a_or_b(BYTE*, const BYTE*, int, int, int, int, int, int, int)':
blend_common.cpp:149:7: error: 'memcpy' was not declared in this scope
  149 |       memcpy(p1, p2, rowsize);
      |       ^~~~~~
```