### PR TITLE
Resizers: fix AVX512 fixed-kernel coefficient layout

### DIFF
--- a/avs_core/filters/intel/resample_avx512.h
+++ b/avs_core/filters/intel/resample_avx512.h
@@ -133,7 +133,7 @@ void resizer_h_avx512_generic_float_pix16_sub4_ks_4_8_16(BYTE * dst8, const BYTE
 
 // transpose and hi/lo unpack of resampling program for permute-based H-resizers
 // allocate and fill pixel_coefficient_AVX512_H coeffs buffer of the ResamplingProgram
-void resize_prepare_coeffs_AVX512_H(ResamplingProgram* p, IScriptEnvironment* env, int iSamplesInTheGroup, int iGroupsCount);
+void resize_prepare_coeffs_AVX512_H(ResamplingProgram* p, IScriptEnvironment* env, int iSamplesInTheGroup, int iGroupsCount, int prepared_filter_size);
 // allocate and fill pixel_coefficient_AVX512_float_H for float permutex-based H-resizers (ks16 variants)
 void resize_prepare_coeffs_AVX512_float_H(ResamplingProgram* p, IScriptEnvironment* env);
 

--- a/avs_core/filters/intel/resample_avx512b.cpp
+++ b/avs_core/filters/intel/resample_avx512b.cpp
@@ -3458,7 +3458,7 @@ template void resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks16_pretranspos
 template void resize_h_planar_uint16_avx512_permutex_vstripe_mp_4s16_ks48_pretransposed_coeffs_base<false>(BYTE* dst8, const BYTE* src8, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height, int bits_per_pixel);
 template void resize_h_planar_uint16_avx512_permutex_vstripe_mp_4s16_ks48_pretransposed_coeffs_base<true>(BYTE* dst8, const BYTE* src8, int dst_pitch, int src_pitch, ResamplingProgram* program, int width, int height, int bits_per_pixel);
 
-void resize_prepare_coeffs_AVX512_H(ResamplingProgram* p, IScriptEnvironment* env, int iSamplesInTheGroup, int iGroupsCount) {
+void resize_prepare_coeffs_AVX512_H(ResamplingProgram* p, IScriptEnvironment* env, int iSamplesInTheGroup, int iGroupsCount, int prepared_filter_size) {
   // note: filter_size_real was the max(kernel_sizes[])
   int filter_size_aligned = AlignNumber(p->filter_size_real, p->filter_size_alignment);
   // FIXME: really this needs to be dynamic based on SIMD used in resizer
@@ -3503,8 +3503,10 @@ void resize_prepare_coeffs_AVX512_H(ResamplingProgram* p, IScriptEnvironment* en
 
   const int filter_size_padded = p->filter_size; // aligned, practically the coeff table stride, always mod2 ?
   const int filter_size_real = p->filter_size_real;
-  int filter_size_to_process = filter_size_real;
-  if ((filter_size_real / 2 * 2) != filter_size_real) filter_size_to_process++; // add last zero coeffs to unpack hi/lo, they must present in zero-padded resampling program
+  const int filter_size_to_process = AlignNumber(filter_size_real, 2);
+  const int prepared_filter_size_even = prepared_filter_size > 0
+    ? AlignNumber(prepared_filter_size, 2)
+    : filter_size_to_process;
 
   short* dst = (short*)SIMD_coeff;
 
@@ -3517,12 +3519,9 @@ void resize_prepare_coeffs_AVX512_H(ResamplingProgram* p, IScriptEnvironment* en
       return *(current_coeff + filter_size_padded * std::min(j, avail - 1) + ki);
     };
     // process by 2 rows because madd/dp can only make FMA from 2 unpacked uint16 pairs
-    // ks16 (iSamplesAtATime==32): filter always reads 16 vectors per x-group (advance by 16),
-    // so we must store all filter_size_aligned/2 pairs even when filter_size_real < 16.
-    // Extra iterations access zero-padded taps and produce zero coefficient pairs — harmless.
-    // ks64 (iSamplesAtATime==64): filter advances by filter_size_real*2 (variable), so it uses
-    // filter_size_to_process to store exactly that many pairs — must NOT use filter_size_aligned.
-    const int i_limit = (iSamplesAtATime == 32) ? filter_size_aligned : filter_size_to_process;
+    // Fixed-width kernels load all of their named taps, including zero-padded pairs.
+    // Variable-width kernels advance according to filter_size_real and use only those pairs.
+    const int i_limit = prepared_filter_size > 0 ? prepared_filter_size_even : filter_size_to_process;
     for (int i = 0; i < i_limit; i += 2)
     {
       if (iSamplesAtATime == 64) // 2 groups of 32 coeffs for columns 0..31 and 32..63

--- a/avs_core/filters/resample.cpp
+++ b/avs_core/filters/resample.cpp
@@ -1732,7 +1732,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
 
             Winners: (Fast) resize_h_planar_uint8_avx512_permutex_vstripe_mpz_ks4_vnni (Base) resize_h_planar_uint8_avx512_permutex_vstripe_ks4_base
           */
-          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 4/*prepared_filter_size*/);
           if (has_AVX512_fast)
             return resize_h_planar_uint8_avx512_permutex_vstripe_mpz_ks4_pretransposed_coeffs_vnni;
           else
@@ -1763,14 +1763,14 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
 
           Winners: (Fast) resize_h_planar_uint8_avx512_permutex_vstripe_mpz_ks8_vnni (Base) resize_h_planar_uint8_avx512_permutex_vstripe_ks8_base
           */
-          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 8/*prepared_filter_size*/);
           if (has_AVX512_fast)
             return resize_h_planar_uint8_avx512_permutex_vstripe_mpz_ks8_pretransposed_coeffs_vnni;
           else
             return resize_h_planar_uint8_avx512_permutex_vstripe_mpz_ks8_pretransposed_coeffs_base;
         }
         if (!program->resize_h_planar_gather_permutex_vstripe_check(32/*iSamplesInTheGroup*/, 128/*permutex_index_diff_limit*/, 8/*kernel_size*/)) { // slower ks8 but more downsample ratio for /2
-          resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 2/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 2/*iGroupsCount*/, 8/*prepared_filter_size*/);
           if (has_AVX512_fast)
             return resize_h_planar_uint8_avx512_permutex_vstripe_2s32_ks8_pretransposed_coeffs_vnni;
           else
@@ -1794,7 +1794,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
 
           Winners: (Fast) resize_h_planar_uint8_avx512_permutex_vstripe_mpz_ks16_vnni (Base) resize_h_planar_uint8_avx512_permutex_vstripe_ks16_base
           */
-          resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 16/*prepared_filter_size*/);
           if (has_AVX512_fast)
             return resize_h_planar_uint8_avx512_permutex_vstripe_mpz_ks16_pretransposed_coeffs_vnni;
           else
@@ -1803,7 +1803,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
       }
       if (!program->resize_h_planar_gather_permutex_vstripe_check(32/*iSamplesInTheGroup*/, 128/*permutex_index_diff_limit*/, program->filter_size_real/*kernel_size*/))
       {
-        resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 2/*iGroupsCount*/);
+        resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 2/*iGroupsCount*/, 0/*prepared_filter_size*/);
         if (has_AVX512_fast)
           return resize_h_planar_uint8_avx512_permutex_vstripe_mpz_2s32_ks64_pretransposed_coeffs_vnni;
         else
@@ -1854,7 +1854,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
             Fazit: The MP versions' difference is only two VNNI instructions between BASE/FAST, in benchmarks zero visible speed benefit is seen.
             Winners: (Both mp) (Fast) resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks4_vnni (Base) resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks4_base
           */
-          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 4/*prepared_filter_size*/);
           if (bits_per_pixel < 16) {
             if (has_AVX512_fast)
               return resize_h_planar_uint16_avx512_permutex_vstripe_mp_2s32_ks4_pretransposed_coeffs_vnni<true>;
@@ -1880,7 +1880,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
             Fazit: The MP versions' difference is only two VNNI instructions between BASE/FAST, in benchmarks 1-2% visible speed benefit is seen.
             Winners: (Both mp) (Fast) resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks8_vnni (Base) resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks8_base
           */
-          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 8/*prepared_filter_size*/);
           if (bits_per_pixel < 16) {
             if (has_AVX512_fast)
               return resize_h_planar_uint16_avx512_permutex_vstripe_mp_2s32_ks8_pretransposed_coeffs_vnni<true>;
@@ -1903,7 +1903,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
         // Case E LanczosResize(int(width*0.5 + 0.5), height, taps=2) kernel size 8
         // Case R: LanczosResize(int(width*0.5 + 0.5), height, taps=2) kernel size 8 
         if (!program->resize_h_planar_gather_permutex_vstripe_check(16/*iSamplesInTheGroup*/, 64/*permutex_index_diff_limit*/, 8/*kernel_size*/)) {
-          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 8/*prepared_filter_size*/);
           if (bits_per_pixel < 16) {
             if (has_AVX512_fast)
               return resize_h_planar_uint16_avx512_permutex_vstripe_mp_4s16_ks8_pretransposed_coeffs_vnni<true>;
@@ -1937,7 +1937,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
             resizer_h_avx2_generic_uint16_t (fallback)                  1156 1085 1292
             Winners: (Both mp) (Fast) resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks8_vnni (Base) resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks8_base
           */
-          resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+          resize_prepare_coeffs_AVX512_H(program, env, 32/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 16/*prepared_filter_size*/);
           if (bits_per_pixel < 16) {
             if (has_AVX512_fast)
               return resize_h_planar_uint16_avx512_permutex_vstripe_mp_ks16_pretransposed_coeffs_vnni<true>;
@@ -1962,7 +1962,7 @@ ResamplerH FilteredResizeH::GetResampler(int CPU, int pixelsize, int bits_per_pi
       // The function itself has no hard 48 limit; it loops over filter_size_real directly.
       if (!program->resize_h_planar_gather_permutex_vstripe_check(16/*iSamplesInTheGroup*/, 64/*permutex_index_diff_limit*/, program->filter_size_real/*kernel_size*/))
       {
-        resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/);
+        resize_prepare_coeffs_AVX512_H(program, env, 64/*iSamplesInTheGroup*/, 1/*iGroupsCount*/, 0/*prepared_filter_size*/);
         if (bits_per_pixel < 16) {
           if (has_AVX512_fast)
             return resize_h_planar_uint16_avx512_permutex_vstripe_mp_4s16_ks48_pretransposed_coeffs_vnni<true>;


### PR DESCRIPTION
> Disclosure: This report was prepared by OpenAI Codex, a GPT-based coding agent.
> The GitHub user posting this issue is forwarding the report and is not claiming authorship of the analysis.

```text
[       OK ] Kernels/ResizeVertical8Kernels.MatchesFixedCoefficientReference/Plane8Vertical_Width32_SourceHeight7_TargetHeight5_SrcPitch64_DstPitch64_FilterTriangle_PatternBoundaryRamp_VariantSse2 (1 ms)
[       OK ] Kernels/ResizeVertical8Kernels.MatchesFixedCoefficientReference/Plane8Vertical_Width32_SourceHeight7_TargetHeight5_SrcPitch64_DstPitch64_FilterTriangle_PatternBoundaryRamp_VariantAvx2 (0 ms)
[       OK ] Kernels/ResizeVertical8Kernels.MatchesFixedCoefficientReference/Plane8Vertical_Width64_SourceHeight7_TargetHeight5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base (0 ms)
[       OK ] Kernels/ResizeVertical16Kernels.MatchesFixedCoefficientReference/Plane16Vertical_Bits10_Width32_SourceHeight7_TargetHeight5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantSse2 (0 ms)
[       OK ] Kernels/ResizeVertical16Kernels.MatchesFixedCoefficientReference/Plane16Vertical_Bits10_Width32_SourceHeight7_TargetHeight5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantAvx2 (0 ms)
[       OK ] Kernels/ResizeVertical16Kernels.MatchesFixedCoefficientReference/Plane16Vertical_Bits16_Width32_SourceHeight7_TargetHeight5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantSse2 (0 ms)
[       OK ] Kernels/ResizeVertical16Kernels.MatchesFixedCoefficientReference/Plane16Vertical_Bits16_Width32_SourceHeight7_TargetHeight5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantAvx2 (0 ms)
[       OK ] Kernels/ResizeVertical16Kernels.MatchesFixedCoefficientReference/Plane16Vertical_Bits10_Width64_SourceHeight7_TargetHeight5_SrcPitch256_DstPitch256_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base (1 ms)
[       OK ] Kernels/ResizeVertical16Kernels.MatchesFixedCoefficientReference/Plane16Vertical_Bits16_Width64_SourceHeight7_TargetHeight5_SrcPitch256_DstPitch256_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base (0 ms)
[       OK ] Kernels/ResizeHorizontal8Kernels.MatchesFixedCoefficientReference/Plane8Horizontal_SourceWidth48_TargetWidth32_Height5_SrcPitch64_DstPitch64_FilterTriangle_PatternBoundaryRamp_VariantSsse3 (1 ms)
[       OK ] Kernels/ResizeHorizontal8Kernels.MatchesFixedCoefficientReference/Plane8Horizontal_SourceWidth48_TargetWidth32_Height5_SrcPitch64_DstPitch64_FilterTriangle_PatternBoundaryRamp_VariantAvx2 (0 ms)
[       OK ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits10_SourceWidth48_TargetWidth32_Height5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantSsse3 (0 ms)
[       OK ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits10_SourceWidth48_TargetWidth32_Height5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantAvx2 (0 ms)
[       OK ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits16_SourceWidth48_TargetWidth32_Height5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantSsse3 (0 ms)
[       OK ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits16_SourceWidth48_TargetWidth32_Height5_SrcPitch128_DstPitch128_FilterTriangle_PatternBoundaryRamp_VariantAvx2 (0 ms)
[       OK ] Kernels/ResizeVerticalFloatKernels.MatchesFixedCoefficientReference/PlaneFloatVertical_Width40_SourceHeight7_TargetHeight5_SrcPitch192_DstPitch192_FilterTriangle_PatternFiniteAnchors_VariantSse2 (0 ms)
[       OK ] Kernels/ResizeVerticalFloatKernels.MatchesFixedCoefficientReference/PlaneFloatVertical_Width40_SourceHeight7_TargetHeight5_SrcPitch192_DstPitch192_FilterTriangle_PatternFiniteAnchors_VariantAvx2Fma (0 ms)
[       OK ] Kernels/ResizeVerticalFloatKernels.MatchesFixedCoefficientReference/PlaneFloatVertical_Width64_SourceHeight7_TargetHeight5_SrcPitch320_DstPitch320_FilterTriangle_PatternFiniteAnchors_VariantAvx512Base (1 ms)
[       OK ] Kernels/ResizeHorizontalFloatKernels.MatchesFixedCoefficientReference/PlaneFloatHorizontal_SourceWidth48_TargetWidth32_Height5_SrcPitch256_DstPitch128_FilterTriangle_PatternFiniteAnchors_VariantSsse3 (0 ms)
[       OK ] Kernels/ResizeHorizontalFloatKernels.MatchesFixedCoefficientReference/PlaneFloatHorizontal_SourceWidth48_TargetWidth32_Height5_SrcPitch256_DstPitch128_FilterTriangle_PatternFiniteAnchors_VariantAvx2Fma (0 ms)
[       OK ] Kernels/ResizeHorizontalFloatKernels.MatchesFixedCoefficientReference/PlaneFloatHorizontal_SourceWidth64_TargetWidth64_Height5_SrcPitch320_DstPitch320_FilterTriangle_PatternFiniteAnchors_VariantAvx512Base (0 ms)
[  FAILED  ] 6 tests, listed below:
[  FAILED  ] Kernels/ResizeHorizontal8Kernels.MatchesFixedCoefficientReference/Plane8Horizontal_SourceWidth128_TargetWidth192_Height5_SrcPitch192_DstPitch192_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base, where GetParam() = Plane8Horizontal_SourceWidth128_TargetWidth192_Height5_SrcPitch192_DstPitch192_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base
[  FAILED  ] Kernels/ResizeHorizontal8Kernels.MatchesFixedCoefficientReference/Plane8Horizontal_SourceWidth128_TargetWidth192_Height5_SrcPitch192_DstPitch192_FilterTriangle_PatternBoundaryRamp_VariantAvx512Fast, where GetParam() = Plane8Horizontal_SourceWidth128_TargetWidth192_Height5_SrcPitch192_DstPitch192_FilterTriangle_PatternBoundaryRamp_VariantAvx512Fast
[  FAILED  ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits10_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base, where GetParam() = Plane16Horizontal_Bits10_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base
[  FAILED  ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits10_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Fast, where GetParam() = Plane16Horizontal_Bits10_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Fast
[  FAILED  ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits16_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base, where GetParam() = Plane16Horizontal_Bits16_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Base
[  FAILED  ] Kernels/ResizeHorizontal16Kernels.MatchesFixedCoefficientReference/Plane16Horizontal_Bits16_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Fast, where GetParam() = Plane16Horizontal_Bits16_SourceWidth128_TargetWidth192_Height5_SrcPitch384_DstPitch384_FilterTriangle_PatternBoundaryRamp_VariantAvx512Fast
```

## Summary

Fix the AVX512 horizontal coefficient table layout for fixed-size kernels.

For a small filter such as 2-tap BilinearResize, the coefficient builder previously emitted only one coefficient pair. The ks4 kernels always consume two pairs, so the second load read data belonging to the next output group.

```text
filter_size_real = 2

before:
prepare: [tap0,tap1]
kernel : [tap0,tap1] [tap2,tap3]
                         ^ reads the next group's table data

after:
prepare: [tap0,tap1] [0,0]
kernel : [tap0,tap1] [0,0]
```

Pass the required prepared width explicitly for fixed ks4, ks8, and ks16 kernels. Keep the variable-width ks48 and ks64 layouts based on the actual filter size.

## Regression

Introduced by 351094b4900b
(`Resizers: AVX512 H-resizer kernels using precomputed coeff table (DTL2020)`).

## Validation

On an AVX512 host, the unpatched implementation has 6 failing integer horizontal AVX512 Base/Fast cases. The fix passes all 11 AVX512 Resize cases; the complete Resize suite passes 27 cases.